### PR TITLE
docs: document release-as recovery flow

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -93,6 +93,10 @@ window before the published artifact becomes permanent.
    mailglass_admin dep-pin sync step, so the generated PR is load-bearing.
    The current release path emits package tags such as `mailglass-v<version>`
    and `mailglass_admin-v<version>`.
+   If a broad milestone PR was squash-merged under a non-releasable subject
+   and release-please skips the cut, recover with a tiny follow-up commit that
+   carries a `Release-As: <intended-version>` footer. Do not hand-edit
+   `.release-please-manifest.json` to force the version.
 3. **Approve the `hex-publish` deployment in the GitHub Environment UI.**
    Review the pre-publish summary in the workflow run page (rendered by the
    `prepublish-summary` job per D-15) BEFORE clicking Approve. Verify the


### PR DESCRIPTION
## Scope
Document the release-please recovery path when a squash subject hides releasable history.

## Why
PR #13 merged correctly, but its squash subject was non-releasable, so release-please skipped the intended v0.2.0 cut.

## After merge
I will squash-merge this PR with a commit body that includes Release-As: 0.2.0so release-please opens the real v0.2.0 release path.