### PR TITLE
docs(release): prepare v0.3.0 release surface

### DIFF
--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -4,12 +4,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    # Canonical fallback for v0.2.0 if the release event does not fan out:
+    # Canonical fallback for v0.3.0 if the release event does not fan out:
     # dispatch this workflow against the core release tag (e.g.
-    # `mailglass-v0.2.0`), not `main`.
+    # `mailglass-v0.3.0`), not `main`.
     inputs:
       tag:
-        description: "Git tag/ref to publish from (canonical fallback: mailglass-v0.2.0)"
+        description: "Git tag/ref to publish from (canonical fallback: mailglass-v0.3.0)"
         required: true
         type: string
       dry_run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass-v0.1.1...mailglass-v0.2.0) (2026-04-28)
+## [0.3.0](https://github.com/szTheory/mailglass/compare/mailglass-v0.2.0...mailglass-v0.3.0) (2026-04-29)
 
+Mailglass 0.3.0 is the webhook-coverage-complete release. If you already ship
+on `~> 0.2`, this cut is for teams that want the full first-party webhook
+ingest story across Postmark, SendGrid, Mailgun, SES, and Resend without taking
+on a new migration or codemod path first.
 
-### Documentation
+This is not a `0.2.0`-style migration release. There is no urgent codemod, no
+special rollback procedure, and no new "rewrite your mailables first" story to
+absorb before upgrading.
 
-* document release-as recovery flow ([2272e72](https://github.com/szTheory/mailglass/commit/2272e72c7ef9fa1d2a193a612b0650e5fe4c53a1))
+### Added
+
+- First-party Resend webhook verification and normalization docs, including the
+  raw-body `CachingBodyReader` requirement and explicit opt-in route/config
+  examples.
+- Public release guidance for the now-shipped Mailgun, SES, and Resend webhook
+  providers so the adopter-facing docs match the provider surface that is
+  already in the library.
+
+### Changed
+
+- The webhook guide, README positioning, and release runbook now all describe
+  `0.3.0` as the release where webhook provider coverage is complete.
+- Release fallback examples now use the real `mailglass-v0.3.0` tag path
+  instead of stale `0.2.0` examples.
+
+### Fixed
+
+- Removed duplicate generated `0.2.0` changelog clutter so the current release
+  history reads like a maintainer-owned narrative instead of a mixed generated
+  stub plus curated entry.
 
 ## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass-v0.1.1...mailglass-v0.2.0) (2026-04-28)
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -102,10 +102,9 @@ window before the published artifact becomes permanent.
    `prepublish-summary` job per D-15) BEFORE clicking Approve. Verify the
    file count, total size, CHANGELOG excerpt, and top files all match
    expectations.
-   If the Release Please tag/release exists but `publish-hex` did not fan out,
-   use `workflow_dispatch` on `.github/workflows/publish-hex.yml` with the
-   known core tag (for `0.2.0`: `mailglass-v0.2.0`) instead of improvising a
-   separate publish path or dispatching from `main`.
+   - **Package order:** The workflow guarantees `mailglass` (core) publishes first, then `mailglass_admin` publishes against the newly live core.
+   - **Idempotency:** Both publish steps check `mix hex.info` first and skip the publish command if the version is already live, making the workflow safe to retry.
+   - **Fallback path:** If the Release Please tag/release exists but `publish-hex` did not fan out, dispatch `.github/workflows/publish-hex.yml` manually (with `package=both` and `dry_run=false`). **Do not dispatch from `main`**. Always use the reviewed release tag (for `0.3.0`: `mailglass-v0.3.0`) so the publish run is pinned to the exact commit Release Please tagged.
 4. **Within 60 minutes of publish: smoke-install in a fresh Phoenix app.**
    Set a literal timer when approving the deployment.
    Run:
@@ -113,7 +112,7 @@ window before the published artifact becomes permanent.
        mix archive.install hex phx_new --force
        mix phx.new sandbox --no-ecto --no-mailer --install
        cd sandbox
-       # add {:mailglass, "~> 0.2"}, {:mailglass_admin, "~> 0.2"} to deps
+       # add {:mailglass, "~> 0.3"}, {:mailglass_admin, "~> 0.3"} to deps
        mix deps.get && mix mailglass.install && mix compile --warnings-as-errors
        mix phx.server  # visit http://localhost:4000/dev/mail/
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Add `mailglass` to your dependencies:
 # mix.exs
 def deps do
   [
-    {:mailglass, "~> 0.2"},
-    {:mailglass_admin, "~> 0.2", only: [:dev]}
+    {:mailglass, "~> 0.3"},
+    {:mailglass_admin, "~> 0.3", only: [:dev]}
   ]
 end
 ```
@@ -136,8 +136,8 @@ HTML/Text/Raw/Headers tabs, live-editable assigns.
 - **Normalized webhook events** — Anymail event taxonomy verbatim
   (`queued`, `sent`, `bounced`, `delivered`, `opened`, `clicked`,
   `complained`, `unsubscribed`, …) with `reject_reason` enum.
-  Postmark (Basic Auth + IP allowlist) and SendGrid (ECDSA) are
-  first-party in v0.2, and matched `:bounced`, `:complained`, and
+  Postmark, SendGrid, Mailgun, SES, and Resend are all shipped
+  first-party providers, and matched `:bounced`, `:complained`, and
   `:unsubscribed` events project suppressions automatically.
 - **Test assertions** — `assert_mail_sent/1`, `last_mail/0`,
   `wait_for_mail/1`, plus `MailerCase`, `WebhookCase`, `AdminCase`
@@ -155,8 +155,8 @@ HTML/Text/Raw/Headers tabs, live-editable assigns.
 
 | Package             | Status                   | What it is |
 |---------------------|--------------------------|------------|
-| `mailglass`         | v0.2 public surface      | Core library: mailables, rendering, delivery pipeline, event ledger, webhook ingest, streams, unsubscribe, suppressions, tenancy. |
-| `mailglass_admin`   | v0.2 (dev-preview only)  | Mountable LiveView preview in dev. Prod-mountable sent-mail inbox + event timeline + suppression UI arrive in v0.5. |
+| `mailglass`         | v0.3 public surface      | Core library: mailables, rendering, delivery pipeline, event ledger, webhook ingest, streams, unsubscribe, suppressions, tenancy. |
+| `mailglass_admin`   | v0.3 (dev-preview only)  | Mountable LiveView preview in dev. Prod-mountable sent-mail inbox + event timeline + suppression UI arrive in v0.5. |
 | `mailglass_inbound` | v0.5+                    | Inbound routing (Action Mailbox equivalent): recipient/subject/header matchers, ingress plugs per provider, storage adapters, Oban routing. |
 
 ## Roadmap
@@ -165,8 +165,8 @@ HTML/Text/Raw/Headers tabs, live-editable assigns.
   setter API, `mix mailglass.upgrade.v0_2`, message-stream policy,
   RFC 8058 unsubscribe, webhook-driven suppression projection, linked
   release hardening, and release-blocking Tier 1 docs.
-- **v0.5 — Deliverability + admin** — Mailgun/SES/Resend webhook verification,
-  prod-mountable admin, `mix mail.doctor` deliverability checks,
+- **v0.5 — Deliverability + admin** — prod-mountable admin,
+  `mix mail.doctor` deliverability checks,
   per-tenant adapter resolver, per-domain rate limiting.
 - **v1.0** — API stability lock, production references, long-lived
   deprecation policy.

--- a/guides/webhooks.md
+++ b/guides/webhooks.md
@@ -3,8 +3,9 @@
 This guide walks through mounting Mailglass webhook ingest in your
 Phoenix app. Mailglass ships first-party verifiers for Postmark (Basic
 Auth), SendGrid (ECDSA P-256), and Mailgun (HMAC-SHA256 over the JSON
-body's `signature.timestamp <> signature.token`). SES and Resend land
-later behind the same internal `Mailglass.Webhook.Provider` behaviour.
+body's `signature.timestamp <> signature.token`). SES (RSA-signed SNS)
+and Resend (Svix-style HMAC) are also shipped providers behind the same
+`Mailglass.Webhook.Provider` behaviour.
 
 ## 1. Install + endpoint wiring
 
@@ -60,18 +61,21 @@ This generates two POST routes, each handled by
   * `POST /webhooks/postmark`
   * `POST /webhooks/sendgrid`
 
-Mailgun stays off the default zero-arg mount. Opt in explicitly:
+Mailgun, SES, and Resend stay off the default zero-arg mount. Opt in
+explicitly:
 
 ```elixir
 scope "/", MyAppWeb do
   pipe_through :mailglass_webhooks
-  mailglass_webhook_routes "/webhooks", providers: [:postmark, :sendgrid, :mailgun]
+  mailglass_webhook_routes "/webhooks", providers: [:postmark, :sendgrid, :mailgun, :ses, :resend]
 end
 ```
 
 That adds:
 
   * `POST /webhooks/mailgun`
+  * `POST /webhooks/ses`
+  * `POST /webhooks/resend`
 
 ### Step 3 — Configure provider credentials
 
@@ -176,6 +180,39 @@ your endpoint is reachable. No manual confirmation step is required.
 | Click | `:clicked` | Requires click tracking enabled on config set |
 | Rendering Failure | `:failed` | Template rendering error |
 | DeliveryDelay | `:deferred` | Transient delivery delay |
+
+### Resend setup
+
+> **Resend is an explicit opt-in provider.** It does not appear in the default
+> route surface. Add `:resend` to your `:providers` list when mounting webhook
+> routes.
+
+```elixir
+mailglass_webhook_routes "/webhooks", providers: [:postmark, :sendgrid, :resend]
+```
+
+```elixir
+config :mailglass, :resend,
+  enabled: true,
+  secret: System.fetch_env!("RESEND_WEBHOOK_SECRET"),
+  timestamp_tolerance_seconds: 300
+```
+
+The secret must look like `whsec_...`. Mailglass verifies the Svix headers
+`svix-id`, `svix-timestamp`, and `svix-signature` against the exact raw request
+body, so `Mailglass.Webhook.CachingBodyReader` is required at the endpoint
+boundary before JSON parsing happens.
+
+Resend currently normalizes these event types into the public Mailglass event
+taxonomy:
+
+| Resend event | Normalized type |
+|--------------|-----------------|
+| `email.sent` | `:sent` |
+| `email.delivered` | `:delivered` |
+| `email.delivery_delayed` | `:deferred` |
+| `email.bounced` | `:bounced` |
+| `email.complained` | `:complained` |
 
 ## 2. Multi-tenant patterns
 

--- a/mailglass_admin/CHANGELOG.md
+++ b/mailglass_admin/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to `mailglass_admin` will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning coordinated with `mailglass` core via Release Please linked-versions.
 
-## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass_admin-v0.1.1...mailglass_admin-v0.2.0) (2026-04-28)
+## [0.3.0](https://github.com/szTheory/mailglass/compare/mailglass_admin-v0.2.0...mailglass_admin-v0.3.0) (2026-04-29)
 
+`mailglass_admin` 0.3.0 stays version-paired with `mailglass` 0.3.0. There is
+no admin-only migration story in this release; bump the sibling packages
+together and take the updated core webhook/docs surface as a coordinated cut.
 
-### Miscellaneous Chores
+### Changed
 
-* **mailglass_admin:** Synchronize mailglass-sibling-group versions
+- The preview package stays aligned to the core `0.3.0` release line and its
+  maintainer-written release narrative.
 
 ## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass_admin-v0.1.1...mailglass_admin-v0.2.0) (2026-04-28)
 


### PR DESCRIPTION
## Summary
- add curated v0.3.0 changelog entries for core and admin
- document shipped Resend webhook setup and remove stale provider-coverage wording
- align README and maintainer release fallback examples with the v0.3.0 release path

## Verification
- mix mailglass.publish.check --package mailglass
- mix mailglass.publish.check --package mailglass_admin
