### PR TITLE
docs(release): prepare v0.3.0 release surface

### DIFF
--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -4,12 +4,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    # Canonical fallback for v0.2.0 if the release event does not fan out:
+    # Canonical fallback for v0.3.0 if the release event does not fan out:
     # dispatch this workflow against the core release tag (e.g.
-    # `mailglass-v0.2.0`), not `main`.
+    # `mailglass-v0.3.0`), not `main`.
     inputs:
       tag:
-        description: "Git tag/ref to publish from (canonical fallback: mailglass-v0.2.0)"
+        description: "Git tag/ref to publish from (canonical fallback: mailglass-v0.3.0)"
         required: true
         type: string
       dry_run:

--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -83,7 +83,8 @@ jobs:
           while ! pg_isready -h localhost -U postgres; do
             sleep 1
           done
-          MIX_ENV=test mix ecto.create -r Mailglass.TestRepo --quiet
+          export MIX_ENV=test
+          mix ecto.create -r Mailglass.TestRepo --quiet
       - name: Install deps (admin)
         if: ${{ github.event.inputs.package != 'mailglass' }}
         working-directory: mailglass_admin

--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -80,7 +80,9 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          until pg_isready -h localhost -U postgres; do sleep 1; done
+          while ! pg_isready -h localhost -U postgres; do
+            sleep 1
+          done
           MIX_ENV=test mix ecto.create -r Mailglass.TestRepo --quiet
       - name: Install deps (admin)
         if: ${{ github.event.inputs.package != 'mailglass' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass-v0.1.1...mailglass-v0.2.0) (2026-04-28)
+## [0.3.0](https://github.com/szTheory/mailglass/compare/mailglass-v0.2.0...mailglass-v0.3.0) (2026-04-29)
 
+Mailglass 0.3.0 is the webhook-coverage-complete release. If you already ship
+on `~> 0.2`, this cut is for teams that want the full first-party webhook
+ingest story across Postmark, SendGrid, Mailgun, SES, and Resend without taking
+on a new migration or codemod path first.
 
-### Documentation
+This is not a `0.2.0`-style migration release. There is no urgent codemod, no
+special rollback procedure, and no new "rewrite your mailables first" story to
+absorb before upgrading.
 
-* document release-as recovery flow ([2272e72](https://github.com/szTheory/mailglass/commit/2272e72c7ef9fa1d2a193a612b0650e5fe4c53a1))
+### Added
+
+- First-party Resend webhook verification and normalization docs, including the
+  raw-body `CachingBodyReader` requirement and explicit opt-in route/config
+  examples.
+- Public release guidance for the now-shipped Mailgun, SES, and Resend webhook
+  providers so the adopter-facing docs match the provider surface that is
+  already in the library.
+
+### Changed
+
+- The webhook guide, README positioning, and release runbook now all describe
+  `0.3.0` as the release where webhook provider coverage is complete.
+- Release fallback examples now use the real `mailglass-v0.3.0` tag path
+  instead of stale `0.2.0` examples.
+
+### Fixed
+
+- Removed duplicate generated `0.2.0` changelog clutter so the current release
+  history reads like a maintainer-owned narrative instead of a mixed generated
+  stub plus curated entry.
 
 ## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass-v0.1.1...mailglass-v0.2.0) (2026-04-28)
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -102,10 +102,9 @@ window before the published artifact becomes permanent.
    `prepublish-summary` job per D-15) BEFORE clicking Approve. Verify the
    file count, total size, CHANGELOG excerpt, and top files all match
    expectations.
-   If the Release Please tag/release exists but `publish-hex` did not fan out,
-   use `workflow_dispatch` on `.github/workflows/publish-hex.yml` with the
-   known core tag (for `0.2.0`: `mailglass-v0.2.0`) instead of improvising a
-   separate publish path or dispatching from `main`.
+   - **Package order:** The workflow guarantees `mailglass` (core) publishes first, then `mailglass_admin` publishes against the newly live core.
+   - **Idempotency:** Both publish steps check `mix hex.info` first and skip the publish command if the version is already live, making the workflow safe to retry.
+   - **Fallback path:** If the Release Please tag/release exists but `publish-hex` did not fan out, dispatch `.github/workflows/publish-hex.yml` manually (with `package=both` and `dry_run=false`). **Do not dispatch from `main`**. Always use the reviewed release tag (for `0.3.0`: `mailglass-v0.3.0`) so the publish run is pinned to the exact commit Release Please tagged.
 4. **Within 60 minutes of publish: smoke-install in a fresh Phoenix app.**
    Set a literal timer when approving the deployment.
    Run:
@@ -113,7 +112,7 @@ window before the published artifact becomes permanent.
        mix archive.install hex phx_new --force
        mix phx.new sandbox --no-ecto --no-mailer --install
        cd sandbox
-       # add {:mailglass, "~> 0.2"}, {:mailglass_admin, "~> 0.2"} to deps
+       # add {:mailglass, "~> 0.3"}, {:mailglass_admin, "~> 0.3"} to deps
        mix deps.get && mix mailglass.install && mix compile --warnings-as-errors
        mix phx.server  # visit http://localhost:4000/dev/mail/
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Add `mailglass` to your dependencies:
 # mix.exs
 def deps do
   [
-    {:mailglass, "~> 0.2"},
-    {:mailglass_admin, "~> 0.2", only: [:dev]}
+    {:mailglass, "~> 0.3"},
+    {:mailglass_admin, "~> 0.3", only: [:dev]}
   ]
 end
 ```
@@ -136,8 +136,8 @@ HTML/Text/Raw/Headers tabs, live-editable assigns.
 - **Normalized webhook events** — Anymail event taxonomy verbatim
   (`queued`, `sent`, `bounced`, `delivered`, `opened`, `clicked`,
   `complained`, `unsubscribed`, …) with `reject_reason` enum.
-  Postmark (Basic Auth + IP allowlist) and SendGrid (ECDSA) are
-  first-party in v0.2, and matched `:bounced`, `:complained`, and
+  Postmark, SendGrid, Mailgun, SES, and Resend are all shipped
+  first-party providers, and matched `:bounced`, `:complained`, and
   `:unsubscribed` events project suppressions automatically.
 - **Test assertions** — `assert_mail_sent/1`, `last_mail/0`,
   `wait_for_mail/1`, plus `MailerCase`, `WebhookCase`, `AdminCase`
@@ -155,8 +155,8 @@ HTML/Text/Raw/Headers tabs, live-editable assigns.
 
 | Package             | Status                   | What it is |
 |---------------------|--------------------------|------------|
-| `mailglass`         | v0.2 public surface      | Core library: mailables, rendering, delivery pipeline, event ledger, webhook ingest, streams, unsubscribe, suppressions, tenancy. |
-| `mailglass_admin`   | v0.2 (dev-preview only)  | Mountable LiveView preview in dev. Prod-mountable sent-mail inbox + event timeline + suppression UI arrive in v0.5. |
+| `mailglass`         | v0.3 public surface      | Core library: mailables, rendering, delivery pipeline, event ledger, webhook ingest, streams, unsubscribe, suppressions, tenancy. |
+| `mailglass_admin`   | v0.3 (dev-preview only)  | Mountable LiveView preview in dev. Prod-mountable sent-mail inbox + event timeline + suppression UI arrive in v0.5. |
 | `mailglass_inbound` | v0.5+                    | Inbound routing (Action Mailbox equivalent): recipient/subject/header matchers, ingress plugs per provider, storage adapters, Oban routing. |
 
 ## Roadmap
@@ -165,8 +165,8 @@ HTML/Text/Raw/Headers tabs, live-editable assigns.
   setter API, `mix mailglass.upgrade.v0_2`, message-stream policy,
   RFC 8058 unsubscribe, webhook-driven suppression projection, linked
   release hardening, and release-blocking Tier 1 docs.
-- **v0.5 — Deliverability + admin** — Mailgun/SES/Resend webhook verification,
-  prod-mountable admin, `mix mail.doctor` deliverability checks,
+- **v0.5 — Deliverability + admin** — prod-mountable admin,
+  `mix mail.doctor` deliverability checks,
   per-tenant adapter resolver, per-domain rate limiting.
 - **v1.0** — API stability lock, production references, long-lived
   deprecation policy.

--- a/guides/webhooks.md
+++ b/guides/webhooks.md
@@ -3,8 +3,9 @@
 This guide walks through mounting Mailglass webhook ingest in your
 Phoenix app. Mailglass ships first-party verifiers for Postmark (Basic
 Auth), SendGrid (ECDSA P-256), and Mailgun (HMAC-SHA256 over the JSON
-body's `signature.timestamp <> signature.token`). SES and Resend land
-later behind the same internal `Mailglass.Webhook.Provider` behaviour.
+body's `signature.timestamp <> signature.token`). SES (RSA-signed SNS)
+and Resend (Svix-style HMAC) are also shipped providers behind the same
+`Mailglass.Webhook.Provider` behaviour.
 
 ## 1. Install + endpoint wiring
 
@@ -60,18 +61,21 @@ This generates two POST routes, each handled by
   * `POST /webhooks/postmark`
   * `POST /webhooks/sendgrid`
 
-Mailgun stays off the default zero-arg mount. Opt in explicitly:
+Mailgun, SES, and Resend stay off the default zero-arg mount. Opt in
+explicitly:
 
 ```elixir
 scope "/", MyAppWeb do
   pipe_through :mailglass_webhooks
-  mailglass_webhook_routes "/webhooks", providers: [:postmark, :sendgrid, :mailgun]
+  mailglass_webhook_routes "/webhooks", providers: [:postmark, :sendgrid, :mailgun, :ses, :resend]
 end
 ```
 
 That adds:
 
   * `POST /webhooks/mailgun`
+  * `POST /webhooks/ses`
+  * `POST /webhooks/resend`
 
 ### Step 3 — Configure provider credentials
 
@@ -176,6 +180,39 @@ your endpoint is reachable. No manual confirmation step is required.
 | Click | `:clicked` | Requires click tracking enabled on config set |
 | Rendering Failure | `:failed` | Template rendering error |
 | DeliveryDelay | `:deferred` | Transient delivery delay |
+
+### Resend setup
+
+> **Resend is an explicit opt-in provider.** It does not appear in the default
+> route surface. Add `:resend` to your `:providers` list when mounting webhook
+> routes.
+
+```elixir
+mailglass_webhook_routes "/webhooks", providers: [:postmark, :sendgrid, :resend]
+```
+
+```elixir
+config :mailglass, :resend,
+  enabled: true,
+  secret: System.fetch_env!("RESEND_WEBHOOK_SECRET"),
+  timestamp_tolerance_seconds: 300
+```
+
+The secret must look like `whsec_...`. Mailglass verifies the Svix headers
+`svix-id`, `svix-timestamp`, and `svix-signature` against the exact raw request
+body, so `Mailglass.Webhook.CachingBodyReader` is required at the endpoint
+boundary before JSON parsing happens.
+
+Resend currently normalizes these event types into the public Mailglass event
+taxonomy:
+
+| Resend event | Normalized type |
+|--------------|-----------------|
+| `email.sent` | `:sent` |
+| `email.delivered` | `:delivered` |
+| `email.delivery_delayed` | `:deferred` |
+| `email.bounced` | `:bounced` |
+| `email.complained` | `:complained` |
 
 ## 2. Multi-tenant patterns
 

--- a/lib/mailglass/webhook/providers/mailgun.ex
+++ b/lib/mailglass/webhook/providers/mailgun.ex
@@ -186,7 +186,9 @@ defmodule Mailglass.Webhook.Providers.Mailgun do
   defp map_event(%{"event" => "unsubscribed"}), do: {:unsubscribed, nil}
 
   defp map_event(%{"event" => "failed", "severity" => "temporary"}), do: {:deferred, nil}
-  defp map_event(%{"event" => "failed", "severity" => "permanent", "reason" => "bounce"}), do: {:bounced, :bounced}
+
+  defp map_event(%{"event" => "failed", "severity" => "permanent", "reason" => "bounce"}),
+    do: {:bounced, :bounced}
 
   defp map_event(%{"event" => "failed", "severity" => "permanent"} = event_data) do
     reason = event_data["reason"] |> map_reject_reason()
@@ -203,13 +205,22 @@ defmodule Mailglass.Webhook.Providers.Mailgun do
   defp map_event(_other), do: {:unknown, nil}
 
   defp map_reject_reason(reason) when reason in ["generic", "bounce"], do: :bounced
-  defp map_reject_reason(reason) when reason in ["suppress-bounce", "suppress-complaint"], do: :blocked
+
+  defp map_reject_reason(reason) when reason in ["suppress-bounce", "suppress-complaint"],
+    do: :blocked
+
   defp map_reject_reason(reason) when reason in ["spam", "spamtrap"], do: :spam
-  defp map_reject_reason(reason) when reason in ["unsubscribe", "suppress-unsubscribe"], do: :unsubscribed
+
+  defp map_reject_reason(reason) when reason in ["unsubscribe", "suppress-unsubscribe"],
+    do: :unsubscribed
+
   defp map_reject_reason(_reason), do: :other
 
   defp stringify_timestamp(value) when is_integer(value), do: Integer.to_string(value)
-  defp stringify_timestamp(value) when is_float(value), do: :erlang.float_to_binary(value, [:compact])
+
+  defp stringify_timestamp(value) when is_float(value),
+    do: :erlang.float_to_binary(value, [:compact])
+
   defp stringify_timestamp(value) when is_binary(value), do: value
   defp stringify_timestamp(_value), do: nil
 

--- a/lib/mailglass/webhook/providers/resend.ex
+++ b/lib/mailglass/webhook/providers/resend.ex
@@ -70,11 +70,13 @@ defmodule Mailglass.Webhook.Providers.Resend do
   end
 
   defp verify_timestamp(timestamp, tolerance) do
-    with {timestamp_int, ""} <- Integer.parse(timestamp) do
-      diff = abs(System.system_time(:second) - timestamp_int)
-      if diff <= tolerance, do: :ok, else: {:error, :timestamp_skew}
-    else
-      _ -> {:error, :malformed_timestamp}
+    case Integer.parse(timestamp) do
+      {timestamp_int, ""} ->
+        diff = abs(System.system_time(:second) - timestamp_int)
+        if diff <= tolerance, do: :ok, else: {:error, :timestamp_skew}
+
+      _ ->
+        {:error, :malformed_timestamp}
     end
   end
 

--- a/lib/mailglass/webhook/providers/ses.ex
+++ b/lib/mailglass/webhook/providers/ses.ex
@@ -76,8 +76,11 @@ defmodule Mailglass.Webhook.Providers.SES do
     # Verify RSA signature
     digest =
       case sig_version do
-        "1" -> :sha
-        "2" -> :sha256
+        "1" ->
+          :sha
+
+        "2" ->
+          :sha256
 
         other ->
           raise SignatureError.new(:malformed_header,
@@ -121,7 +124,10 @@ defmodule Mailglass.Webhook.Providers.SES do
         []
 
       _other ->
-        Logger.warning("[mailglass] SES normalize: unexpected SNS payload shape or non-Notification type")
+        Logger.warning(
+          "[mailglass] SES normalize: unexpected SNS payload shape or non-Notification type"
+        )
+
         []
     end
   end
@@ -568,7 +574,16 @@ defmodule Mailglass.Webhook.Providers.SES do
   # adding lookup value — telemetry emission never touches metadata, so the PII
   # policy does not apply to the DB path, but we keep the field absent to keep the
   # schema minimal and consistent across all normalizers.
-  defp build_event(payload, sns_message_id, type, reject_reason, provider_event_id, _email, record_type, extra_metadata) do
+  defp build_event(
+         payload,
+         sns_message_id,
+         type,
+         reject_reason,
+         provider_event_id,
+         _email,
+         record_type,
+         extra_metadata
+       ) do
     mail = Map.get(payload, "mail", %{})
     ses_message_id = to_string_or_nil(mail["messageId"])
 

--- a/lib/mailglass/webhook/providers/ses/trust_policy.ex
+++ b/lib/mailglass/webhook/providers/ses/trust_policy.ex
@@ -36,7 +36,15 @@ defmodule Mailglass.Webhook.Providers.SES.TrustPolicy do
   @spec valid_cert_url?(binary()) :: boolean()
   def valid_cert_url?(url) when is_binary(url) do
     case URI.parse(url) do
-      %URI{scheme: "https", host: host, port: port, userinfo: nil, fragment: nil, path: path, query: nil}
+      %URI{
+        scheme: "https",
+        host: host,
+        port: port,
+        userinfo: nil,
+        fragment: nil,
+        path: path,
+        query: nil
+      }
       when is_binary(host) and is_binary(path) and port in [nil, 443] ->
         Regex.match?(@cert_host_pattern, host) and String.ends_with?(path, ".pem")
 

--- a/mailglass_admin/CHANGELOG.md
+++ b/mailglass_admin/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to `mailglass_admin` will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning coordinated with `mailglass` core via Release Please linked-versions.
 
-## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass_admin-v0.1.1...mailglass_admin-v0.2.0) (2026-04-28)
+## [0.3.0](https://github.com/szTheory/mailglass/compare/mailglass_admin-v0.2.0...mailglass_admin-v0.3.0) (2026-04-29)
 
+`mailglass_admin` 0.3.0 stays version-paired with `mailglass` 0.3.0. There is
+no admin-only migration story in this release; bump the sibling packages
+together and take the updated core webhook/docs surface as a coordinated cut.
 
-### Miscellaneous Chores
+### Changed
 
-* **mailglass_admin:** Synchronize mailglass-sibling-group versions
+- The preview package stays aligned to the core `0.3.0` release line and its
+  maintainer-written release narrative.
 
 ## [0.2.0](https://github.com/szTheory/mailglass/compare/mailglass_admin-v0.1.1...mailglass_admin-v0.2.0) (2026-04-28)
 

--- a/test/mailglass/webhook/plug_mailgun_test.exs
+++ b/test/mailglass/webhook/plug_mailgun_test.exs
@@ -30,7 +30,9 @@ defmodule Mailglass.Webhook.PlugMailgunTest do
   describe "call/2 Mailgun replay response" do
     test "returns 200 on a valid signed Mailgun request" do
       raw_body = Mailglass.WebhookCase.stub_mailgun_fixture("accepted")
-      conn = Mailglass.WebhookCase.mailglass_webhook_conn(:mailgun, raw_body, token: "mailgun-valid-200")
+
+      conn =
+        Mailglass.WebhookCase.mailglass_webhook_conn(:mailgun, raw_body, token: "mailgun-valid-200")
 
       result = WebhookPlug.call(conn, WebhookPlug.init(provider: :mailgun))
 
@@ -60,8 +62,16 @@ defmodule Mailglass.Webhook.PlugMailgunTest do
   describe "call/2 Mailgun bad signature response" do
     test "returns 401 when the Mailgun signature is invalid" do
       raw_body = Mailglass.WebhookCase.stub_mailgun_fixture("accepted")
-      conn = Mailglass.WebhookCase.mailglass_webhook_conn(:mailgun, raw_body, token: "mailgun-bad-signature")
-      tampered_body = String.replace(conn.private[:raw_body], "\"signature\":\"", "\"signature\":\"0", global: false)
+
+      conn =
+        Mailglass.WebhookCase.mailglass_webhook_conn(:mailgun, raw_body,
+          token: "mailgun-bad-signature"
+        )
+
+      tampered_body =
+        String.replace(conn.private[:raw_body], "\"signature\":\"", "\"signature\":\"0",
+          global: false
+        )
 
       tampered_conn =
         conn
@@ -81,7 +91,12 @@ defmodule Mailglass.Webhook.PlugMailgunTest do
   describe "call/2 Mailgun missing config response" do
     test "returns 500 when Mailgun signing config is missing" do
       raw_body = Mailglass.WebhookCase.stub_mailgun_fixture("accepted")
-      conn = Mailglass.WebhookCase.mailglass_webhook_conn(:mailgun, raw_body, token: "mailgun-missing-config")
+
+      conn =
+        Mailglass.WebhookCase.mailglass_webhook_conn(:mailgun, raw_body,
+          token: "mailgun-missing-config"
+        )
+
       prior = Application.get_env(:mailglass, :mailgun)
 
       Application.put_env(:mailglass, :mailgun,

--- a/test/mailglass/webhook/providers/ses_test.exs
+++ b/test/mailglass/webhook/providers/ses_test.exs
@@ -82,7 +82,10 @@ defmodule Mailglass.Webhook.Providers.SESTest do
       CertCache.put(@cert_url, public_key, future)
 
       raw = sign_fixture(load_ses_fixture("notification_delivery"), private_key)
-      tampered = String.replace(raw, "\"Message\":", "\"Message\":\"TAMPERED\", \"X\":", global: false)
+
+      tampered =
+        String.replace(raw, "\"Message\":", "\"Message\":\"TAMPERED\", \"X\":", global: false)
+
       refute tampered == raw
 
       err = catch_raised(fn -> SES.verify!(tampered, [], @config) end)
@@ -136,7 +139,7 @@ defmodule Mailglass.Webhook.Providers.SESTest do
       raw = load_ses_fixture("notification_bounce_permanent")
       events = SES.normalize(raw, [])
 
-      assert length(events) >= 1
+      assert events != []
       [event | _] = events
       assert %Event{type: :bounced, reject_reason: :bounced} = event
       assert event.metadata["provider"] == "ses"

--- a/test/support/webhook_case.ex
+++ b/test/support/webhook_case.ex
@@ -162,7 +162,11 @@ defmodule Mailglass.WebhookCase do
       `opts[:timestamp]` (string) or `System.system_time(:second)` as a
       string.
   """
-  @spec mailglass_webhook_conn(:postmark | :sendgrid | :mailgun | :ses | :resend, binary(), keyword()) ::
+  @spec mailglass_webhook_conn(
+          :postmark | :sendgrid | :mailgun | :ses | :resend,
+          binary(),
+          keyword()
+        ) ::
           Plug.Conn.t()
   def mailglass_webhook_conn(provider, raw_body, opts \\ [])
 
@@ -237,7 +241,8 @@ defmodule Mailglass.WebhookCase do
           :crypto.strong_rand_bytes(32)
       end
 
-    sig = Mailglass.WebhookFixtures.sign_resend_payload(svix_id, svix_timestamp, raw_body, secret_bytes)
+    sig =
+      Mailglass.WebhookFixtures.sign_resend_payload(svix_id, svix_timestamp, raw_body, secret_bytes)
 
     base_conn(:resend, raw_body)
     |> Plug.Conn.put_req_header("svix-id", svix_id)


### PR DESCRIPTION
## Summary
- add curated v0.3.0 changelog entries for core and admin
- document shipped Resend webhook setup and remove stale provider-coverage wording
- align README and maintainer release fallback examples with the v0.3.0 release path
- fix existing quality-gate blockers surfaced by CI on the release prep branch

## Verification
- mix mailglass.publish.check --package mailglass
- mix mailglass.publish.check --package mailglass_admin
- mix format --check-formatted
- mix credo --strict
- mix docs --warnings-as-errors
