### PR TITLE
fix(release): unblock v0.3.1 CI for Hex publish

### DIFF
--- a/guides/migration-from-swoosh.md
+++ b/guides/migration-from-swoosh.md
@@ -15,8 +15,8 @@ Add mailglass to your dependencies:
 ```elixir
 def deps do
   [
-    {:mailglass, "~> 0.2"},
-    {:mailglass_admin, "~> 0.2", only: [:dev]}
+    {:mailglass, "~> 0.3"},
+    {:mailglass_admin, "~> 0.3", only: [:dev]}
   ]
 end
 ```

--- a/guides/webhooks.md
+++ b/guides/webhooks.md
@@ -161,8 +161,7 @@ your endpoint is reachable. No manual confirmation step is required.
 > sources pointing to the same topic, you will receive duplicate events per message.
 > The `(provider, provider_event_id)` uniqueness constraint prevents duplicate rows in
 > the event ledger, but each source still produces an ingest attempt. Point only one
-> SES notification source at each SNS topic unless you intentionally want both signals
-> (D-18).
+> SES notification source at each SNS topic unless you intentionally want both signals.
 
 #### Supported SES events
 
@@ -353,7 +352,7 @@ own 2 s statement timeout (see §7) bounds ingest latency.
 
 ### Auto-suppression behavior
 
-Mailglass v0.2 projects suppressions automatically after a verified
+Mailglass v0.3 projects suppressions automatically after a verified
 webhook event is matched to a delivery:
 
 - `:complained` -> address-wide suppression

--- a/lib/mailglass/config.ex
+++ b/lib/mailglass/config.ex
@@ -413,7 +413,7 @@ defmodule Mailglass.Config do
       {Mailglass.Adapters.Fake, []}
   """
   @doc since: "0.1.0"
-  @spec new!(keyword()) :: keyword() | map()
+  @spec new!(keyword()) :: keyword()
   def new!(opts \\ []) when is_list(opts) do
     opts
     |> NimbleOptions.validate!(@schema)

--- a/lib/mailglass/webhook/ingest.ex
+++ b/lib/mailglass/webhook/ingest.ex
@@ -367,6 +367,13 @@ defmodule Mailglass.Webhook.Ingest do
     extract_event_provider_id(first) || ""
   end
 
+  # Resend (Svix) sends one event per webhook with a stable `id` like
+  # "evt_..."; Phase 14 normalize/2 plumbs that into
+  # Event.metadata["provider_event_id"], same convention as Postmark.
+  defp derive_webhook_provider_event_id(:resend, _raw_body, [first | _]) do
+    extract_event_provider_id(first) || ""
+  end
+
   defp derive_webhook_provider_event_id(_provider, _raw_body, []), do: ""
 
   # Per revision W9 — Plans 02 + 03 normalize/2 emit STRING keys in

--- a/lib/mailglass/webhook/ingest.ex
+++ b/lib/mailglass/webhook/ingest.ex
@@ -119,7 +119,7 @@ defmodule Mailglass.Webhook.Ingest do
   @spec ingest_multi(atom(), binary(), [Event.t()]) ::
           {:ok, map()} | {:error, term()}
   def ingest_multi(provider, raw_body, events)
-      when provider in [:postmark, :sendgrid, :mailgun] and is_binary(raw_body) and
+      when provider in [:postmark, :sendgrid, :mailgun, :resend] and is_binary(raw_body) and
              is_list(events) do
     # Tenancy.tenant_id!/0 is the fail-loud accessor — raises %TenancyError{:unstamped}
     # when the process-dict key is absent. Unlike Tenancy.current/0 (which falls back

--- a/lib/mailglass/webhook/providers/mailgun_replay_cache.ex
+++ b/lib/mailglass/webhook/providers/mailgun_replay_cache.ex
@@ -40,6 +40,6 @@ defmodule Mailglass.Webhook.Providers.MailgunReplayCache do
   end
 
   @doc since: "0.2.1"
-  @spec table() :: atom()
+  @spec table() :: :mailglass_webhook_mailgun_replay_cache
   def table, do: @table
 end

--- a/lib/mailglass/webhook/providers/mailgun_replay_cache/table_owner.ex
+++ b/lib/mailglass/webhook/providers/mailgun_replay_cache/table_owner.ex
@@ -27,6 +27,6 @@ defmodule Mailglass.Webhook.Providers.MailgunReplayCache.TableOwner do
   end
 
   @doc since: "0.2.1"
-  @spec table() :: atom()
+  @spec table() :: :mailglass_webhook_mailgun_replay_cache
   def table, do: @table
 end

--- a/lib/mailglass/webhook/providers/ses/cert_cache.ex
+++ b/lib/mailglass/webhook/providers/ses/cert_cache.ex
@@ -70,6 +70,6 @@ defmodule Mailglass.Webhook.Providers.SES.CertCache do
   end
 
   @doc since: "0.3.0"
-  @spec table() :: atom()
+  @spec table() :: :mailglass_webhook_ses_cert_cache
   def table, do: @table
 end

--- a/lib/mailglass/webhook/providers/ses/cert_cache/table_owner.ex
+++ b/lib/mailglass/webhook/providers/ses/cert_cache/table_owner.ex
@@ -31,6 +31,6 @@ defmodule Mailglass.Webhook.Providers.SES.CertCache.TableOwner do
   end
 
   @doc since: "0.3.0"
-  @spec table() :: atom()
+  @spec table() :: :mailglass_webhook_ses_cert_cache
   def table, do: @table
 end

--- a/lib/mix/tasks/mailglass.docs.check.ex
+++ b/lib/mix/tasks/mailglass.docs.check.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Mailglass.Docs.Check do
   use Boundary, classify_to: Mailglass
 
-  @shortdoc "Checks Tier 1 docs for leaked internal IDs and stale v0.2 surface drift"
+  @shortdoc "Checks Tier 1 docs for leaked internal IDs and stale v0.3 surface drift"
 
   @moduledoc """
   Fail the build if Tier 1 docs leak internal IDs or drift back to known
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Mailglass.Docs.Check do
       |> Kernel.++(tier1_surface_issues())
 
     if issues == [] do
-      Mix.shell().info("[mailglass.docs.check] OK — Tier 1 docs match the v0.2 release surface.")
+      Mix.shell().info("[mailglass.docs.check] OK — Tier 1 docs match the v0.3 release surface.")
       :ok
     else
       Enum.each(issues, &emit_issue/1)

--- a/lib/mix/tasks/mailglass.docs.check.ex
+++ b/lib/mix/tasks/mailglass.docs.check.ex
@@ -32,8 +32,14 @@ defmodule Mix.Tasks.Mailglass.Docs.Check do
   ]
   @tier1_surface_rules %{
     "README.md" => %{
-      required: ["{:mailglass, \"~> 0.2\"}", "mix mailglass.install", "RFC 8058 List-Unsubscribe"],
-      forbidden: ["~> 0.1", "verify.phase_07", "v0.1 in development", "and — at v0.5 — RFC 8058"]
+      required: ["{:mailglass, \"~> 0.3\"}", "mix mailglass.install", "RFC 8058 List-Unsubscribe"],
+      forbidden: [
+        "~> 0.1",
+        "~> 0.2",
+        "verify.phase_07",
+        "v0.1 in development",
+        "and — at v0.5 — RFC 8058"
+      ]
     },
     "guides/getting-started.md" => %{
       required: ["mix mailglass.install", "|> to(user.email)", "|> subject(\"Welcome\")"],
@@ -49,7 +55,7 @@ defmodule Mix.Tasks.Mailglass.Docs.Check do
     },
     "guides/migration-from-swoosh.md" => %{
       required: [
-        "{:mailglass, \"~> 0.2\"}",
+        "{:mailglass, \"~> 0.3\"}",
         "Mailglass still accepts a plain `%Swoosh.Email{}`",
         "assert {:ok, _delivery} = Mailglass.deliver(email)"
       ],
@@ -79,7 +85,7 @@ defmodule Mix.Tasks.Mailglass.Docs.Check do
     },
     "guides/webhooks.md" => %{
       required: [
-        "Mailglass v0.2 projects suppressions automatically",
+        "Mailglass v0.3 projects suppressions automatically",
         "[:mailglass, :suppression, :auto_added, :stop]",
         "mix mailglass.suppressions.resync --tenant-id <tenant>"
       ],

--- a/test/example/README.md
+++ b/test/example/README.md
@@ -12,7 +12,7 @@ Refresh both snapshots with:
 <!-- GOLDEN_FRESH_START -->
 # tree
 - .gitignore sha256:aae815b9313ef60fb99d51bec324f3de1cea5256d6bbf58a660578b3e2d5815c
-- .mailglass.toml sha256:ef2ec4ef5891db6124b38d8160b59f3c52809da7a9574d727c9a2bf51a3162e9
+- .mailglass.toml sha256:4cba18c3446d78a2afd2ddd36fd1f73d42296cae8695b904b1dbe0bf6e4ab57d
 - config/runtime.exs sha256:2cc43bcd5ede9de69f9b6dcfb5b57e2474b81fdd01b084637342598fa2845c93
 - lib/example/mail/default_mailable.ex sha256:f49e7723d7476bb2e321483a52e4bbe331b8895ae6407ce48e5f6d3673be971b
 - lib/example/mail/worker.ex sha256:fa1970e47ea9b544e2f8fa99595880d02af26793561415b89b8e98439ea301a7
@@ -31,7 +31,7 @@ Refresh both snapshots with:
 
 
 @@ .mailglass.toml
-installer_version = "0.2.0"
+installer_version = "0.3.0"
 last_run_at = "<LAST_RUN_AT>"
 
 [paths]
@@ -169,7 +169,7 @@ end
 <!-- GOLDEN_NO_ADMIN_START -->
 # tree
 - .gitignore sha256:aae815b9313ef60fb99d51bec324f3de1cea5256d6bbf58a660578b3e2d5815c
-- .mailglass.toml sha256:ddb09707e5e9ba578a3fdbda387d5869bffd146f1a3a52c8f9893cc2e1483b35
+- .mailglass.toml sha256:bc01c1402ef4e7c86e28fc8d19c350b7fa67faf8aeda4e7f36aeee747321f788
 - config/runtime.exs sha256:2cc43bcd5ede9de69f9b6dcfb5b57e2474b81fdd01b084637342598fa2845c93
 - lib/example/mail/default_mailable.ex sha256:f49e7723d7476bb2e321483a52e4bbe331b8895ae6407ce48e5f6d3673be971b
 - lib/example/mail/worker.ex sha256:fa1970e47ea9b544e2f8fa99595880d02af26793561415b89b8e98439ea301a7
@@ -188,7 +188,7 @@ end
 
 
 @@ .mailglass.toml
-installer_version = "0.2.0"
+installer_version = "0.3.0"
 last_run_at = "<LAST_RUN_AT>"
 
 [paths]

--- a/test/mailglass/docs_contract_test.exs
+++ b/test/mailglass/docs_contract_test.exs
@@ -3,7 +3,7 @@ defmodule Mailglass.DocsContractTest do
   import Mailglass.DocsHelpers
 
   describe "README.md contract" do
-    test "installation snippet targets the v0.2 surface" do
+    test "installation snippet targets the v0.3 surface" do
       blocks = extract_code_blocks("README.md")
       install_block = Enum.find(blocks, &(&1 =~ "mix mailglass.install"))
 
@@ -12,8 +12,9 @@ defmodule Mailglass.DocsContractTest do
       refute Enum.any?(blocks, &String.contains?(&1, "mix verify.phase_07"))
 
       readme = File.read!("README.md")
-      assert readme =~ "{:mailglass, \"~> 0.2\"}"
+      assert readme =~ "{:mailglass, \"~> 0.3\"}"
       refute readme =~ "v0.1 in development"
+      refute readme =~ "{:mailglass, \"~> 0.2\"}"
     end
 
     test "Quickstart snippet compiles" do

--- a/test/mailglass/webhook/providers/resend_webhook_plug_test.exs
+++ b/test/mailglass/webhook/providers/resend_webhook_plug_test.exs
@@ -1,0 +1,119 @@
+defmodule Mailglass.Webhook.PlugResendTest do
+  use Mailglass.WebhookCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mailglass.TestRepo
+  alias Mailglass.Webhook.Plug, as: WebhookPlug
+  alias Mailglass.Webhook.WebhookEvent
+
+  setup do
+    TestRepo.query!("TRUNCATE TABLE mailglass_webhook_events CASCADE", [])
+    TestRepo.query!("TRUNCATE TABLE mailglass_events CASCADE", [])
+    :ok
+  end
+
+  test "WebhookCase can build a signed Resend conn from raw bytes" do
+    raw_body = Mailglass.WebhookCase.stub_resend_fixture("delivered")
+    conn = Mailglass.WebhookCase.mailglass_webhook_conn(:resend, raw_body)
+
+    assert conn.request_path == "/webhooks/resend"
+    assert get_req_header(conn, "content-type") == ["application/json"]
+    assert [_] = get_req_header(conn, "svix-id")
+    assert [_] = get_req_header(conn, "svix-timestamp")
+    assert ["v1," <> _] = get_req_header(conn, "svix-signature")
+  end
+
+  describe "call/2 Resend valid signature" do
+    test "returns 200 on a valid signed Resend request" do
+      raw_body = Mailglass.WebhookCase.stub_resend_fixture("delivered")
+      conn = Mailglass.WebhookCase.mailglass_webhook_conn(:resend, raw_body)
+
+      result = WebhookPlug.call(conn, WebhookPlug.init(provider: :resend))
+
+      assert result.status == 200
+      assert TestRepo.aggregate(WebhookEvent, :count) == 1
+    end
+  end
+
+  describe "call/2 Resend bad signature response" do
+    test "returns 401 when the Resend body is tampered" do
+      raw_body = Mailglass.WebhookCase.stub_resend_fixture("delivered")
+      conn = Mailglass.WebhookCase.mailglass_webhook_conn(:resend, raw_body)
+      tampered_conn = Plug.Conn.put_private(conn, :raw_body, raw_body <> "tampered")
+
+      {result, log} =
+        with_log(fn ->
+          WebhookPlug.call(tampered_conn, WebhookPlug.init(provider: :resend))
+        end)
+
+      assert result.status == 401
+      assert log =~ "provider=resend"
+      refute log =~ raw_body
+    end
+
+    test "returns 401 when the Resend svix-timestamp is stale" do
+      raw_body = Mailglass.WebhookCase.stub_resend_fixture("delivered")
+      stale_ts = Integer.to_string(System.system_time(:second) - 400)
+      svix_id = "msg_stale_#{System.unique_integer([:positive])}"
+
+      secret_bytes =
+        case Application.fetch_env(:mailglass, :resend) do
+          {:ok, cfg} ->
+            "whsec_" <> encoded = Keyword.fetch!(cfg, :secret)
+            Base.decode64!(encoded)
+
+          :error ->
+            :crypto.strong_rand_bytes(32)
+        end
+
+      sig = Mailglass.WebhookFixtures.sign_resend_payload(svix_id, stale_ts, raw_body, secret_bytes)
+
+      conn =
+        :post
+        |> Plug.Test.conn("/webhooks/resend", raw_body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_private(:raw_body, raw_body)
+        |> Plug.Conn.put_req_header("svix-id", svix_id)
+        |> Plug.Conn.put_req_header("svix-timestamp", stale_ts)
+        |> Plug.Conn.put_req_header("svix-signature", "v1," <> sig)
+
+      {result, log} =
+        with_log(fn ->
+          WebhookPlug.call(conn, WebhookPlug.init(provider: :resend))
+        end)
+
+      assert result.status == 401
+      assert log =~ "provider=resend"
+      refute log =~ raw_body
+    end
+
+    test "returns 401 when svix-id header is missing" do
+      raw_body = Mailglass.WebhookCase.stub_resend_fixture("delivered")
+      svix_timestamp = Integer.to_string(System.system_time(:second))
+
+      conn =
+        :post
+        |> Plug.Test.conn("/webhooks/resend", raw_body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_private(:raw_body, raw_body)
+        |> Plug.Conn.put_req_header("svix-timestamp", svix_timestamp)
+        |> Plug.Conn.put_req_header("svix-signature", "v1,invalidsig")
+
+      {result, log} =
+        with_log(fn ->
+          WebhookPlug.call(conn, WebhookPlug.init(provider: :resend))
+        end)
+
+      assert result.status == 401
+      assert log =~ "provider=resend"
+      refute log =~ raw_body
+    end
+  end
+
+  describe "call/2 Resend explicit route execution" do
+    test "init/1 accepts :resend as an explicit provider" do
+      assert Keyword.get(WebhookPlug.init(provider: :resend), :provider) == :resend
+    end
+  end
+end

--- a/test/support/fixtures/webhooks/resend/delivered.json
+++ b/test/support/fixtures/webhooks/resend/delivered.json
@@ -1,0 +1,9 @@
+{
+  "id": "evt_delivered_001",
+  "type": "email.delivered",
+  "created_at": "2026-04-29T12:00:00Z",
+  "data": {
+    "email_id": "email_delivered_001",
+    "to": ["test@example.com"]
+  }
+}


### PR DESCRIPTION
## Summary

`mailglass-v0.3.0` and `mailglass_admin-v0.3.0` were tagged but **never published to Hex.pm** because `publish-hex.yml`'s `gate-ci-green` job blocks until `ci.yml` succeeds on the tagged SHA — and CI on `20f4d92` (the v0.3.0 release commit) failed on **Tests, Dialyzer, Docs leaked-IDs, and Installer Golden**.

This PR fixes every job, all in the same family of two carryover gaps from Phases 14/17 (Resend wiring) and routine v0.2 → v0.3 surface drift:

- **Tests**:
  - `Mailglass.Webhook.Ingest.ingest_multi/3` guard didn't accept `:resend`. Phase 14/17 wired Resend through the plug + router static dispatch but missed the persistence boundary.
  - `Mailglass.Webhook.Ingest.derive_webhook_provider_event_id/3` had no `:resend` clause — same family of bug.
  - Plug-level integration test added (`Mailglass.Webhook.PlugResendTest`) so this can't regress.
  - `Mailglass.DocsContractTest` updated for v0.3 surface lock.
  - Install golden snapshot regenerated for the v0.3.0 `installer_version` literal.
- **Dialyzer**:
  - 4 ETS table accessor specs tightened from `atom()` to the concrete singleton atom (mailgun replay cache + SES cert cache, owners + readers).
  - `Config.new!/1` spec narrowed from `keyword() | map()` to `keyword()` to match success typing.
- **Docs / REL-02 leaked-IDs**:
  - Removed a `(D-18)` planning-decision reference that leaked into `guides/webhooks.md`.
  - Locked Tier 1 surface tokens (`mix mailglass.docs.check` rules + the auto-suppression callout) advance to `~> 0.3` and `Mailglass v0.3 projects suppressions automatically`.
  - `forbidden` list adds `~> 0.2` so reverts trip the gate.
- **Installer Golden Gate**:
  - `test/example/README.md` regenerated via `MIX_INSTALLER_ACCEPT_GOLDEN=1 mix test test/mailglass/install/install_golden_test.exs --warnings-as-errors`. Diff is exactly the `0.2.0` → `0.3.0` `installer_version` literal in two variants.

The `mailglass-v0.3.0` GitHub release stays as a historical orphan tag — `0.3.0` was never on Hex.pm so nothing public depends on it. Once this PR merges, Release Please opens the linked-versions `0.3.1` PR; merging that fires the publish chain on a green SHA.

## Test plan

- [x] `mix test` — 897 tests / 0 failures
- [x] `mix dialyzer` — 4 errors, all skipped (pre-existing whitelist), 0 unskipped
- [x] `mix verify.installer.golden` — passes
- [x] `mix mailglass.docs.check` — `OK — Tier 1 docs match the v0.3 release surface`
- [x] `mix mailglass.publish.check --package mailglass` — `conflict=0`
- [x] `mix mailglass.publish.check --package mailglass_admin` — `conflict=0`
- [ ] CI green on this PR head (gates the release-please cascade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)