### PR TITLE
fix(install): normalize installer_version in golden snapshot

### DIFF
--- a/test/example/README.md
+++ b/test/example/README.md
@@ -12,7 +12,7 @@ Refresh both snapshots with:
 <!-- GOLDEN_FRESH_START -->
 # tree
 - .gitignore sha256:aae815b9313ef60fb99d51bec324f3de1cea5256d6bbf58a660578b3e2d5815c
-- .mailglass.toml sha256:4cba18c3446d78a2afd2ddd36fd1f73d42296cae8695b904b1dbe0bf6e4ab57d
+- .mailglass.toml sha256:2eb67153858109cfc1ea31f6bd136d61d45de0ca61f63ed66ad4454d5d84b015
 - config/runtime.exs sha256:2cc43bcd5ede9de69f9b6dcfb5b57e2474b81fdd01b084637342598fa2845c93
 - lib/example/mail/default_mailable.ex sha256:f49e7723d7476bb2e321483a52e4bbe331b8895ae6407ce48e5f6d3673be971b
 - lib/example/mail/worker.ex sha256:fa1970e47ea9b544e2f8fa99595880d02af26793561415b89b8e98439ea301a7
@@ -31,7 +31,7 @@ Refresh both snapshots with:
 
 
 @@ .mailglass.toml
-installer_version = "0.3.0"
+installer_version = "<INSTALLER_VERSION>"
 last_run_at = "<LAST_RUN_AT>"
 
 [paths]
@@ -169,7 +169,7 @@ end
 <!-- GOLDEN_NO_ADMIN_START -->
 # tree
 - .gitignore sha256:aae815b9313ef60fb99d51bec324f3de1cea5256d6bbf58a660578b3e2d5815c
-- .mailglass.toml sha256:bc01c1402ef4e7c86e28fc8d19c350b7fa67faf8aeda4e7f36aeee747321f788
+- .mailglass.toml sha256:aec16ba421bc8a80613ad651d490fb0bfbbe71e6c5fc715f08904884ad3cf76a
 - config/runtime.exs sha256:2cc43bcd5ede9de69f9b6dcfb5b57e2474b81fdd01b084637342598fa2845c93
 - lib/example/mail/default_mailable.ex sha256:f49e7723d7476bb2e321483a52e4bbe331b8895ae6407ce48e5f6d3673be971b
 - lib/example/mail/worker.ex sha256:fa1970e47ea9b544e2f8fa99595880d02af26793561415b89b8e98439ea301a7
@@ -188,7 +188,7 @@ end
 
 
 @@ .mailglass.toml
-installer_version = "0.3.0"
+installer_version = "<INSTALLER_VERSION>"
 last_run_at = "<LAST_RUN_AT>"
 
 [paths]

--- a/test/support/installer_fixture_helpers.ex
+++ b/test/support/installer_fixture_helpers.ex
@@ -88,6 +88,7 @@ defmodule Mailglass.Test.InstallerFixtureHelpers do
     |> normalize_migration_ts()
     |> normalize_last_run_at()
     |> normalize_secret()
+    |> normalize_installer_version()
     |> String.trim()
   end
 
@@ -114,10 +115,19 @@ defmodule Mailglass.Test.InstallerFixtureHelpers do
     |> normalize_migration_ts()
     |> normalize_last_run_at()
     |> normalize_secret()
+    |> normalize_installer_version()
   end
 
   defp normalize_last_run_at(snapshot) do
     Regex.replace(~r/(last_run_at = ")[^"]+(")/, snapshot, "\\1<LAST_RUN_AT>\\2")
+  end
+
+  defp normalize_installer_version(snapshot) do
+    Regex.replace(
+      ~r/(installer_version\s*=\s*")\d+\.\d+\.\d+[^"]*(")/,
+      snapshot,
+      "\\1<INSTALLER_VERSION>\\2"
+    )
   end
 
   defp ensure_host_skeleton!(fixture_root) do


### PR DESCRIPTION
## Summary

Followup to PRs #20 and #22. The install golden snapshot at `test/example/README.md` froze the literal `installer_version = "0.3.0"` value written by the installer into `.mailglass.toml`. So when Release Please bumped `mix.exs` to 0.3.1, the v0.3.1 release commit's CI failed on:

- **Tests**: `Mailglass.Install.GoldenTest` (snapshot mismatch on the `installer_version` literal + cascading sha256 differences for the toml file).
- **Installer Golden Gate**: same root cause — runs the same test with `--warnings-as-errors`.

This kept `gate-ci-green` red, blocking the v0.3.1 publish.

The structural fix:

- Add `normalize_installer_version/1` to `test/support/installer_fixture_helpers.ex`, matching the existing `migration_ts / secret / last_run_at / tmp_path` placeholder pattern.
- Apply it in both `normalize_snapshot/1` (golden body comparison) and `normalize_for_digest/1` (per-file sha256s in the tree manifest).
- Rebase the snapshot once with `MIX_INSTALLER_ACCEPT_GOLDEN=1 mix test test/mailglass/install/install_golden_test.exs --warnings-as-errors`.

Result: the snapshot now reads `installer_version = "<INSTALLER_VERSION>"` and stays stable across all future patch / minor / major bumps, so the gate is only triggered by *real* installer-output changes.

## Test plan

- [x] `mix test test/mailglass/install/install_golden_test.exs test/mailglass/docs_contract_test.exs` — 7 tests / 0 failures
- [x] `mix verify.installer.golden` — passes
- [x] `mix dialyzer` — clean (no spec changes here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)