### PR TITLE
chore(v0.1.2): release-engineering + infra cleanup batch

### DIFF
--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -134,6 +134,14 @@ jobs:
     if: ${{ needs.cron-guard.outputs.should_run == 'true' }}
     timeout-minutes: 8
     steps:
+      - name: Validate VERSION is semver
+        env:
+          VERSION: ${{ needs.cron-guard.outputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?$ ]]; then
+            echo "::error::VERSION='$VERSION' is not valid semver — refusing to run smoke. Check cron-guard version resolution."
+            exit 1
+          fi
       - name: Set up OTP + Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93  # v1.24.0
         with:


### PR DESCRIPTION
## Summary

This PR closes out the v0.1.2 release-engineering and infra-cleanup batch captured in `.planning/todos/pending/` on 2026-04-26. After auditing every TODO against the current codebase (2026-05-03 HEAD), **all core fixes were already landed during the v0.2/v0.3 development phases** (2026-04-28 – 2026-04-29). This PR:

1. Adds the one remaining concrete improvement from the bundle (semver early-exit guard in `post-publish-smoke.yml`).
2. Documents each TODO's status so the planning artifacts can be retired.

> ⚠️ **Mix compile + test not verified locally** — Elixir/Mix is not installed in the agent's sandbox. The change is a single-step YAML addition with no Elixir code touched; CI is the verification gate.

---

## TODO Status

### ✅ TODO #1 + #2 (consolidated): publish-hex trigger gate + post-publish-smoke VERSION resolution

**Files:** `.github/workflows/publish-hex.yml`, `.github/workflows/post-publish-smoke.yml`

**Premise status: Invalidated.** Both files were completely rewritten in `feat(15-03)` (commit `9639da0`, 2026-04-28) and were created fresh with `on: release: types: [published]` as the auto-trigger — eliminating the `workflow_run` + `head_branch` bug entirely. The `post-publish-smoke` `cron-guard` job reads `version` from `context.payload.release.tag_name` (not `head_branch`), so `VERSION=main` can no longer occur via that path.

The TODO recommended `push: tags` as the trigger; the actual fix used `release: published`. Both solve the root problem. The `release` event fires when release-please creates a GitHub Release, which is the definitive "publish is authorized" signal.

**What changed in this PR:**

- [x] Added `Validate VERSION is semver` step to `wait-for-index` (belt-and-suspenders from TODO #2 acceptance criteria — fails in <1 s if a malformed VERSION ever slips past `cron-guard`, instead of timing out after 5 minutes on `mix hex.info mailglass main`).

**Remaining acceptance criteria from the TODOs:**

- [x] `publish-hex.yml` auto-fires without manual dispatch (via `release: published` trigger, not `push: tags` as recommended — equivalent outcome)
- [x] `post-publish-smoke` reads `VERSION=0.1.2`, not `VERSION=main`
- [x] Early validation step that fails fast on malformed VERSION (added in this PR)

---

### ✅ TODO #3: Add installer goldens to `mix mailglass.publish.check`

**File:** `lib/mix/tasks/mailglass.publish.check.ex`

**Premise status: Invalidated.** `verify_installer_goldens/1` was added in `fix(release): recover sibling publish validation` (commit `db5f06f`, 2026-04-29). It's called at the top of `execute_package/2` (before the tarball build) for the `:mailglass` package, with a descriptive error message including the regen command.

- [x] `mix mailglass.publish.check` fails fast when installer goldens drift
- [x] Error message includes the exact regen command (`mix verify.installer`)
- [x] Runs as part of `prepublish-summary` in publish-hex.yml (no workflow change needed)

---

### ✅ TODO #4: Exclude CLAUDE.md from published HexDocs

**File:** `mix.exs`

**Premise status: Invalidated.** `CLAUDE.md` is not present in the `extras:` list (lines 306–323 of current `mix.exs`) and the `Overview` group contains only `["README.md"]`. The fix was present before the 2026-04-28 workflow rewrite.

- [x] `CLAUDE.md` removed from `extras:` list
- [x] `CLAUDE.md` removed from `Overview` group in `groups_for_extras:`
- [x] `README.md` still renders under Overview

---

### ✅ TODO #5: Advisory Matrix — missing DB setup + Elixir 1.17 compat

**File:** `.github/workflows/advisory-matrix.yml`

**Premise status: Invalidated.** Current `advisory-matrix.yml`:

- Elixir 1.17 row dropped (comment: `# REL-06: Elixir 1.17 removed — mailglass requires elixir "~> 1.18"`).
- `mix ecto.create -r Mailglass.TestRepo --quiet` runs before `mix test --warnings-as-errors --exclude provider_live` (lines 71–77).

Both Path 1 fixes from the recommendation are in place.

- [x] Elixir 1.17 row dropped (matches `elixir: "~> 1.18"` in `mix.exs`)
- [x] `mix ecto.create` runs before advisory tests
- [x] Advisory Matrix is green on main HEAD (per workflow YAML; actual run verification deferred to CI)

---

### ✅ TODO #6: Rename `verify.phase_NN` aliases to semantic names

**File:** `mix.exs`, `README.md`

**Premise status: Invalidated.** Semantic aliases (`verify.foundation`, `verify.persistence`, `verify.send_pipeline`, `verify.webhooks`, `verify.installer`) are fully defined in `mix.exs` (lines 175–213). Deprecated `verify.phase_NN` pass-throughs (lines 219–230) delegate to the semantic aliases. `README.md` already uses `mix verify.foundation` and `mix verify.cold_start`. Both `preferred_envs` entries (`:test`) are declared for all aliases in `cli/0`.

- [x] Semantic aliases defined
- [x] Deprecated `verify.phase_NN` pass-throughs in place for one cycle
- [x] README updated (uses `verify.foundation`, not `verify.phase_07`)

---

## TODOs excluded from this batch

| File | Reason |
|---|---|
| `2026-04-26-mailable-api-too-much-swoosh-leakage.md` | v0.2 API design discussion — not a v0.1.2 infra fix |
| `2026-04-26-release-please-extra-files-no-op-on-managed-mix-exs.md` | Lessons-learned doc only — no action items |

---

## What to review

- `post-publish-smoke.yml` — new `Validate VERSION is semver` step (8-line addition, no other changes).
- The PR body itself is the audit record for the six TODOs — confirm the "Premise: Invalidated" findings match your recollection of what was fixed during v0.3 prep.

---

## Hard rules compliance

- ❌ No `Release-As: 0.1.2` pushed — this is for human review only.
- ❌ PR not merged — draft, awaiting review.
- ✅ No Hex tarballs, published versions, or git tags touched.
- ✅ All existing GitHub Action SHAs unchanged (only YAML step added, no new `uses:` references).
- ✅ `CLAUDE.md` "Things Not To Do" list respected throughout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzVRJJpQTdxRVAeVcfqJrK)_