### PR TITLE
fix(ci): de-matrix required checks and automate release-PR merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,19 +85,17 @@ jobs:
   compile_no_optional_deps:
     name: Compile No Optional Deps (Elixir 1.18 / OTP 27)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - elixir: "1.18"
-            otp: "27"
+    # Required check — keep matrix-free. A 1-combo matrix makes GitHub append
+    # " (1.18, 27)" to the check name, which then no longer matches the required
+    # status-check context registered in scripts/setup_branch_protection.sh.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up OTP + Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93  # v1.24.0
         with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+          elixir-version: "1.18"
+          otp-version: "27"
       - name: Cache deps
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -113,11 +111,8 @@ jobs:
   support_contract_core:
     name: Support Contract Core (Elixir 1.18 / OTP 27)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - elixir: "1.18"
-            otp: "27"
+    # Required check — keep matrix-free (see compile_no_optional_deps): a 1-combo
+    # matrix appends " (1.18, 27)" to the name and breaks the required-context match.
     services:
       postgres:
         image: postgres:16-alpine
@@ -143,8 +138,8 @@ jobs:
       - name: Set up OTP + Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93  # v1.24.0
         with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+          elixir-version: "1.18"
+          otp-version: "27"
       - name: Cache deps
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -545,11 +540,8 @@ jobs:
   support_contract_admin:
     name: Support Contract Admin (Elixir 1.18 / OTP 27)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - elixir: "1.18"
-            otp: "27"
+    # Required check — keep matrix-free (see compile_no_optional_deps): a 1-combo
+    # matrix appends " (1.18, 27)" to the name and breaks the required-context match.
     services:
       postgres:
         image: postgres:16-alpine
@@ -575,8 +567,8 @@ jobs:
       - name: Set up OTP + Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93  # v1.24.0
         with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+          elixir-version: "1.18"
+          otp-version: "27"
       - name: Cache deps
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -814,11 +806,8 @@ jobs:
   trust_lane_repo_head:
     name: Trust Lane Repo Head (Elixir 1.18 / OTP 27)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - elixir: "1.18"
-            otp: "27"
+    # Required check — keep matrix-free (see compile_no_optional_deps): a 1-combo
+    # matrix appends " (1.18, 27)" to the name and breaks the required-context match.
     services:
       postgres:
         image: postgres:16-alpine
@@ -844,8 +833,8 @@ jobs:
       - name: Set up OTP + Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93  # v1.24.0
         with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+          elixir-version: "1.18"
+          otp-version: "27"
       - name: Cache deps
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,17 +104,23 @@ jobs:
       # gets rewritten. We sync it ourselves on the release-please PR branch
       # after the action runs. Idempotent — exits clean if the pin is already
       # correct or if there's no release-please PR pending.
-      # Ceremony rule: review this generated PR diff before merge. The repo's
+      # Note: the release PR auto-merges on green (see "Arm auto-merge" below),
+      # so review the generated diff during the CI window if needed. The repo's
       # linked-version dep pin is custom, so the release PR is not a vanilla
       # release-please artifact.
       #
-      # Recursion-safe: pushes authenticated with GITHUB_TOKEN do NOT trigger
-      # further workflow runs (GitHub anti-recursion guarantee).
+      # CI trigger: this checkout uses RELEASE_PLEASE_TOKEN (a PAT) so the sync
+      # commit pushed below is authored by a non-GITHUB_TOKEN identity. That makes
+      # GitHub fire `pull_request: synchronize` -> ci.yml on the synced head, so the
+      # release PR's required checks actually report. A GITHUB_TOKEN push would be
+      # suppressed by anti-recursion, leaving the PR with "no checks reported" and
+      # auto-merge unable to fire.
       - name: Checkout main for sync step
         if: ${{ steps.release-preflight.outputs.should_run == 'true' && steps.release.outputs.prs_created == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Sync sibling package -> mailglass dep pin on release-please branch
         if: ${{ steps.release-preflight.outputs.should_run == 'true' && steps.release.outputs.prs_created == 'true' }}
@@ -205,3 +211,22 @@ jobs:
           git add "${SYNC_PATHS[@]}"
           git commit -m "chore(release-please): sync sibling mailglass dep pins to == $CORE_VERSION + inbound README pin"
           git push origin "$BRANCH"
+
+      # Hands-free release: arm squash auto-merge so the release PR ships the
+      # moment its required checks go green. The Hex publish itself has no
+      # environment gate (intentional — see CLAUDE.md), so this completes the
+      # automated path. Idempotent: re-arming an already-armed PR is a no-op.
+      - name: Arm auto-merge on the release PR
+        if: ${{ steps.release-preflight.outputs.should_run == 'true' && steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH=release-please--branches--main
+          number=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number')
+          if [ -z "$number" ] || [ "$number" = "null" ]; then
+            echo "No open release PR to arm — nothing to do."
+            exit 0
+          fi
+          echo "Arming squash auto-merge on release PR #${number}"
+          gh pr merge "$number" --auto --squash --repo "$GITHUB_REPOSITORY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Encoded for GSD in `~/.claude/get-shit-done/USER-PROFILE.md` (advisor mode, `ven
 
 - **Conventional Commits enforced** (PR title check). Squash-merge workflow.
 - `docs(state):` commit type for `.planning/STATE.md` updates — CI path filters skip them.
-- **Hex publish only from protected ref** + GitHub Environment with required reviewers. `HEX_API_KEY` is never visible to PR jobs.
+- **Hex publish only from a protected ref**, via the `hex-publish` GitHub Environment so `HEX_API_KEY` is never visible to PR jobs. Releases are **fully hands-free**: a Release Please PR auto-merges on green (see `release-please.yml` "Arm auto-merge") and the publish fan-out runs with no human approval gate (the `hex-publish` environment intentionally has no required reviewers). Tightening this back to a required-reviewer gate is a deliberate policy change, not the current default.
 - **All third-party GitHub Actions pinned to commit SHA.** Dependabot watches both `mix.lock` and `.github/workflows/`.
 
 ## Things Not To Do (the short list — full list in PITFALLS.md)


### PR DESCRIPTION
## Summary

Fixes the root cause that left Release Please PR #42 permanently `BLOCKED` ("no required checks reported") even with all jobs green.

The 4 **required** CI jobs used a single-combination `matrix`, so GitHub appended ` (1.18, 27)` to their check names. The required-status-check **contexts** registered in `scripts/setup_branch_protection.sh` (and locked in `test/scripts/required_checks_test.exs`) are **suffix-less**, so they never matched. With `enforce_admins: false` this was invisible on human merges but blocks auto-merge (which can't bypass).

## Changes

- **`ci.yml`** — make `compile_no_optional_deps`, `support_contract_core`, `support_contract_admin`, `trust_lane_repo_head` matrix-free with literal `1.18`/`27`, so their check names equal the registered (locked) contexts. No script/test/docs/branch-protection changes needed.
- **`release-please.yml`** — push the dep-pin sync commit with `RELEASE_PLEASE_TOKEN` (PAT) so `pull_request: synchronize` → `ci.yml` fires on the synced head (a `GITHUB_TOKEN` push is suppressed by anti-recursion → "no checks reported"). Also arm squash auto-merge on the release PR.
- **`CLAUDE.md`** — document the fully hands-free publish (the `hex-publish` environment intentionally has no required reviewers).

## Test plan

- [x] `actionlint` on both workflows
- [x] `mix test test/scripts/required_checks_test.exs` passes **unchanged** (proves the locked contract is preserved)
- [ ] This PR's own CI emits the 4 required checks under their clean (suffix-less) names and they satisfy branch protection → mergeable without admin bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)