### PR TITLE
fix(installer): prevent swoosh 1.26 hackney crash during mix mailglass.install

### DIFF
--- a/lib/mix/tasks/mailglass.install.ex
+++ b/lib/mix/tasks/mailglass.install.ex
@@ -33,6 +33,18 @@ defmodule Mix.Tasks.Mailglass.Install do
       OptionParser.parse(argv, strict: [dry_run: :boolean, no_admin: :boolean, force: :boolean])
 
     validate_cli!(rest, invalid)
+
+    # Swoosh 1.26.0 made `Swoosh.Application.start/2` eagerly call
+    # `Swoosh.ApiClient.init/0`, which raises "missing hackney dependency" when
+    # `:api_client` is unset and no HTTP client dep is present. A fresh
+    # `--no-mailer` host has neither yet — the installer writes
+    # `config :swoosh, :api_client, false` into runtime.exs (see
+    # Mailglass.Installer.Templates), but that only lands *after* this
+    # `app.start`. Set it for the install process here so booting the host app
+    # to probe optional deps doesn't crash before we can persist the config.
+    # `persistent: true` keeps an adopter's own swoosh config (loaded during
+    # `app.config`) authoritative — this only fills the unconfigured window.
+    Application.put_env(:swoosh, :api_client, false, persistent: true)
     Mix.Task.run("app.start")
 
     plan =


### PR DESCRIPTION
## Problem

The `post-publish-smoke` **Consumer install (Phoenix host)** lane is red (tracked in #32). On a fresh `mix phx.new ... --no-mailer` host, `mix mailglass.install` crashes:

```
** (Mix) Could not start application swoosh: ...
   ** (RuntimeError) missing hackney dependency
       (swoosh 1.26.0) lib/swoosh/api_client/hackney.ex:26: Swoosh.ApiClient.Hackney.init/0
```

**Root cause:** `swoosh 1.26.0` made `Swoosh.Application.start/2` eagerly call `Swoosh.ApiClient.init/0`, which raises when `:api_client` is unset and no HTTP client dep (hackney/finch/req) is present. `mix mailglass.install` calls `Mix.Task.run("app.start")` (to probe optional deps like Oban) **before** the installer writes `config :swoosh, :api_client, false` into `runtime.exs`. So the host app boot crashes before the config can be persisted.

This is independent of the mailglass version — it surfaced now purely because of the swoosh upstream change. Prior smoke runs masked it by failing earlier on the Hex-index wait race and never reaching the install step.

## Fix

Set `:api_client` to `false` in the install process **before** `app.start`:

```elixir
Application.put_env(:swoosh, :api_client, false, persistent: true)
Mix.Task.run("app.start")
```

- `persistent: true` keeps an adopter's own swoosh config (loaded during `app.config`) authoritative — this only fills the unconfigured install window.
- The durable `runtime.exs` config is still written by `Mailglass.Installer.Templates` exactly as before (the OPS-01 smoke guard is unaffected).

## Verification

Reproduced against `swoosh 1.26.0` in isolation:

| Scenario | Result |
|---|---|
| `ensure_all_started(:swoosh)` with no config | ❌ raises `missing hackney dependency` |
| `put_env(:swoosh, :api_client, false)` then start | ✅ boots clean |

`Mix.Task.run("app.start")` is the installer's own explicit boot (Mix doesn't auto-start the app for a custom task), so the `put_env` reliably runs first.

Local checks: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` (file), and `mix test test/mailglass/install/` (11 passing) all green.

The consumer-install smoke will validate end-to-end on the next `release: published`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)