### PR TITLE
fix(deps): make igniter optional so a fresh install stays HTTP-client-agnostic

### DIFF
--- a/lib/mix/tasks/mailglass.gen.inbound_route.ex
+++ b/lib/mix/tasks/mailglass.gen.inbound_route.ex
@@ -1,157 +1,165 @@
-defmodule Mix.Tasks.Mailglass.Gen.InboundRoute do
-  @shortdoc "Appends an inbound route/2 to an existing MailglassInbound.Router"
+# Compile-guarded on Igniter (an optional dep) so a fresh mailglass install
+# stays HTTP-client-agnostic. Igniter pulls req/finch/mint; gating the module
+# on `Code.ensure_loaded?(Igniter.Mix.Task)` keeps consumers who don't run
+# this generator from carrying that chain, and keeps the
+# `mix compile --no-optional-deps` lane green. Mirrors the Oban guard in
+# `Mailglass.Oban.TenancyMiddleware`. Adopters add Igniter to run this task.
+if Code.ensure_loaded?(Igniter.Mix.Task) do
+  defmodule Mix.Tasks.Mailglass.Gen.InboundRoute do
+    @shortdoc "Appends an inbound route/2 to an existing MailglassInbound.Router"
 
-  @moduledoc """
-  Appends a `route/2` clause to an existing `MailglassInbound.Router` module.
+    @moduledoc """
+    Appends a `route/2` clause to an existing `MailglassInbound.Router` module.
 
-  The edit is idempotent: running the task twice for the same mailbox is a
-  no-op. The route is appended as the last statement inside the router's
-  `do`-block.
+    The edit is idempotent: running the task twice for the same mailbox is a
+    no-op. The route is appended as the last statement inside the router's
+    `do`-block.
 
-  ## Examples
+    ## Examples
 
-      mix mailglass.gen.inbound_route support@example.com MyApp.SupportMailbox
-      mix mailglass.gen.inbound_route support@example.com MyApp.SupportMailbox --router MyApp.InboundRouter
+        mix mailglass.gen.inbound_route support@example.com MyApp.SupportMailbox
+        mix mailglass.gen.inbound_route support@example.com MyApp.SupportMailbox --router MyApp.InboundRouter
 
-  ## Positional arguments
+    ## Positional arguments
 
-    * `pattern` - the envelope recipient to match (becomes `recipient: "<pattern>"`).
-    * `mailbox` - the mailbox module that handles the matched message.
+      * `pattern` - the envelope recipient to match (becomes `recipient: "<pattern>"`).
+      * `mailbox` - the mailbox module that handles the matched message.
 
-  ## Options
+    ## Options
 
-    * `--router` - the router module to edit. Defaults to `<App>.InboundRouter`.
-    * `--recipient` - override the recipient matcher (defaults to `pattern`).
-    * `--subject` - add a `subject:` matcher to the generated route.
+      * `--router` - the router module to edit. Defaults to `<App>.InboundRouter`.
+      * `--recipient` - override the recipient matcher (defaults to `pattern`).
+      * `--subject` - add a `subject:` matcher to the generated route.
 
-  `--dry-run` is supported as the framework-provided global switch (it is *not*
-  in this task's option schema); it previews the diff and writes nothing.
-  """
+    `--dry-run` is supported as the framework-provided global switch (it is *not*
+    in this task's option schema); it previews the diff and writes nothing.
+    """
 
-  use Boundary, classify_to: Mailglass
-  use Igniter.Mix.Task
+    use Boundary, classify_to: Mailglass
+    use Igniter.Mix.Task
 
-  alias Igniter.Code.Common
-  alias Igniter.Code.Function
+    alias Igniter.Code.Common
+    alias Igniter.Code.Function
 
-  @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
-    %Igniter.Mix.Task.Info{
-      schema: [router: :string, recipient: :string, subject: :string],
-      positional: [:pattern, :mailbox]
-    }
-  end
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        schema: [router: :string, recipient: :string, subject: :string],
+        positional: [:pattern, :mailbox]
+      }
+    end
 
-  @impl Igniter.Mix.Task
-  def igniter(igniter) do
-    %{pattern: pattern, mailbox: mailbox_arg} = igniter.args.positional
-    options = igniter.args.options
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      %{pattern: pattern, mailbox: mailbox_arg} = igniter.args.positional
+      options = igniter.args.options
 
-    mailbox = parse_module(mailbox_arg)
-    recipient = options[:recipient] || pattern
-    subject = options[:subject]
+      mailbox = parse_module(mailbox_arg)
+      recipient = options[:recipient] || pattern
+      subject = options[:subject]
 
-    router = router_module(igniter, options[:router])
+      router = router_module(igniter, options[:router])
 
-    add_route(igniter, router, mailbox, recipient: recipient, subject: subject)
-  end
+      add_route(igniter, router, mailbox, recipient: recipient, subject: subject)
+    end
 
-  @doc """
-  Resolves the router module to edit, honoring an explicit `--router` value and
-  otherwise defaulting to `<App>.InboundRouter`.
-  """
-  @spec router_module(Igniter.t(), String.t() | nil) :: module()
-  def router_module(_igniter, router_arg) when is_binary(router_arg), do: parse_module(router_arg)
+    @doc """
+    Resolves the router module to edit, honoring an explicit `--router` value and
+    otherwise defaulting to `<App>.InboundRouter`.
+    """
+    @spec router_module(Igniter.t(), String.t() | nil) :: module()
+    def router_module(_igniter, router_arg) when is_binary(router_arg), do: parse_module(router_arg)
 
-  def router_module(igniter, _nil) do
-    app_module = Igniter.Project.Application.app_module(igniter) || Test
-    Module.concat([app_module, "InboundRouter"])
-  end
+    def router_module(igniter, _nil) do
+      app_module = Igniter.Project.Application.app_module(igniter) || Test
+      Module.concat([app_module, "InboundRouter"])
+    end
 
-  @doc """
-  Idempotently appends a `route/2` for `mailbox` to `router`'s `do`-block.
+    @doc """
+    Idempotently appends a `route/2` for `mailbox` to `router`'s `do`-block.
 
-  Reused by `mix mailglass.gen.mailbox` so the route-stub insertion shares the
-  exact same dup-scan + add-route logic. When the router module is not found in
-  the project, an actionable notice is emitted (no module is auto-created).
+    Reused by `mix mailglass.gen.mailbox` so the route-stub insertion shares the
+    exact same dup-scan + add-route logic. When the router module is not found in
+    the project, an actionable notice is emitted (no module is auto-created).
 
-  `opts` accepts:
+    `opts` accepts:
 
-    * `:recipient` - the recipient matcher string (required for a useful route).
-    * `:subject` - an optional subject matcher string.
-  """
-  @spec add_route(Igniter.t(), module(), module(), keyword()) :: Igniter.t()
-  def add_route(igniter, router, mailbox, opts) do
-    route_code = route_code(mailbox, opts)
+      * `:recipient` - the recipient matcher string (required for a useful route).
+      * `:subject` - an optional subject matcher string.
+    """
+    @spec add_route(Igniter.t(), module(), module(), keyword()) :: Igniter.t()
+    def add_route(igniter, router, mailbox, opts) do
+      route_code = route_code(mailbox, opts)
 
-    case Igniter.Project.Module.find_and_update_module(igniter, router, fn zipper ->
-           if route_already_present?(zipper, mailbox) do
-             # Idempotent no-op: the route is already declared for this mailbox.
-             {:ok, zipper}
-           else
-             {:ok, Common.add_code(zipper, route_code, placement: :after)}
-           end
-         end) do
-      {:ok, igniter} ->
-        igniter
+      case Igniter.Project.Module.find_and_update_module(igniter, router, fn zipper ->
+             if route_already_present?(zipper, mailbox) do
+               # Idempotent no-op: the route is already declared for this mailbox.
+               {:ok, zipper}
+             else
+               {:ok, Common.add_code(zipper, route_code, placement: :after)}
+             end
+           end) do
+        {:ok, igniter} ->
+          igniter
 
-      {:error, igniter} ->
-        Igniter.add_notice(igniter, """
-        Could not find router #{inspect(router)}.
+        {:error, igniter} ->
+          Igniter.add_notice(igniter, """
+          Could not find router #{inspect(router)}.
 
-        Run `mix mailglass.gen.inbound_router #{inspect(router)}` first, then re-run this task.
+          Run `mix mailglass.gen.inbound_router #{inspect(router)}` first, then re-run this task.
+          """)
+      end
+    end
+
+    @doc """
+    Returns true when the router's `do`-block already declares a `route/2` whose
+    first argument is `mailbox`.
+
+    The zipper must be positioned at the router's `do`-block (as provided by
+    `Igniter.Project.Module.find_and_update_module/3`). Idempotency hinges on
+    `argument_equals?/3` resolving the `{:__aliases__, ...}` mailbox AST against
+    the module atom.
+    """
+    @spec route_already_present?(Sourceror.Zipper.t(), module()) :: boolean()
+    def route_already_present?(zipper, mailbox) do
+      case Function.move_to_function_call_in_current_scope(zipper, :route, 2, fn call_zipper ->
+             Function.argument_equals?(call_zipper, 0, mailbox)
+           end) do
+        {:ok, _zipper} -> true
+        :error -> false
+      end
+    end
+
+    @doc false
+    @spec route_code(module(), keyword()) :: String.t()
+    def route_code(mailbox, opts) do
+      matchers =
+        [recipient: opts[:recipient], subject: opts[:subject]]
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Enum.map_join(", ", fn {key, value} -> "#{key}: #{inspect(value)}" end)
+
+      "route(#{inspect(mailbox)}, #{matchers})"
+    end
+
+    # A well-formed Elixir module name: dot-separated CamelCase segments.
+    @module_name_re ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/
+
+    @doc false
+    @spec parse_module(String.t()) :: module()
+    def parse_module(arg) do
+      unless Regex.match?(@module_name_re, arg) do
+        # Bare `Module.concat(["support@example.com"])` would mint an odd atom like
+        # :"Elixir.support@example.com" that renders badly in the generated route.
+        # Fail fast with an actionable message instead (IN-02).
+        Mix.raise("""
+        Expected a module name like `MyApp.Inbound.Support`, got: #{inspect(arg)}.
+
+        The mailbox/router argument must be dot-separated CamelCase segments
+        (e.g. `MyApp.SupportMailbox`), not an email address or arbitrary string.
         """)
+      end
+
+      Module.concat([arg])
     end
-  end
-
-  @doc """
-  Returns true when the router's `do`-block already declares a `route/2` whose
-  first argument is `mailbox`.
-
-  The zipper must be positioned at the router's `do`-block (as provided by
-  `Igniter.Project.Module.find_and_update_module/3`). Idempotency hinges on
-  `argument_equals?/3` resolving the `{:__aliases__, ...}` mailbox AST against
-  the module atom.
-  """
-  @spec route_already_present?(Sourceror.Zipper.t(), module()) :: boolean()
-  def route_already_present?(zipper, mailbox) do
-    case Function.move_to_function_call_in_current_scope(zipper, :route, 2, fn call_zipper ->
-           Function.argument_equals?(call_zipper, 0, mailbox)
-         end) do
-      {:ok, _zipper} -> true
-      :error -> false
-    end
-  end
-
-  @doc false
-  @spec route_code(module(), keyword()) :: String.t()
-  def route_code(mailbox, opts) do
-    matchers =
-      [recipient: opts[:recipient], subject: opts[:subject]]
-      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-      |> Enum.map_join(", ", fn {key, value} -> "#{key}: #{inspect(value)}" end)
-
-    "route(#{inspect(mailbox)}, #{matchers})"
-  end
-
-  # A well-formed Elixir module name: dot-separated CamelCase segments.
-  @module_name_re ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/
-
-  @doc false
-  @spec parse_module(String.t()) :: module()
-  def parse_module(arg) do
-    unless Regex.match?(@module_name_re, arg) do
-      # Bare `Module.concat(["support@example.com"])` would mint an odd atom like
-      # :"Elixir.support@example.com" that renders badly in the generated route.
-      # Fail fast with an actionable message instead (IN-02).
-      Mix.raise("""
-      Expected a module name like `MyApp.Inbound.Support`, got: #{inspect(arg)}.
-
-      The mailbox/router argument must be dot-separated CamelCase segments
-      (e.g. `MyApp.SupportMailbox`), not an email address or arbitrary string.
-      """)
-    end
-
-    Module.concat([arg])
   end
 end

--- a/lib/mix/tasks/mailglass.gen.inbound_router.ex
+++ b/lib/mix/tasks/mailglass.gen.inbound_router.ex
@@ -1,61 +1,69 @@
-defmodule Mix.Tasks.Mailglass.Gen.InboundRouter do
-  @shortdoc "Scaffolds a new MailglassInbound.Router module"
+# Compile-guarded on Igniter (an optional dep) so a fresh mailglass install
+# stays HTTP-client-agnostic. Igniter pulls req/finch/mint; gating the module
+# on `Code.ensure_loaded?(Igniter.Mix.Task)` keeps consumers who don't run
+# this generator from carrying that chain, and keeps the
+# `mix compile --no-optional-deps` lane green. Mirrors the Oban guard in
+# `Mailglass.Oban.TenancyMiddleware`. Adopters add Igniter to run this task.
+if Code.ensure_loaded?(Igniter.Mix.Task) do
+  defmodule Mix.Tasks.Mailglass.Gen.InboundRouter do
+    @shortdoc "Scaffolds a new MailglassInbound.Router module"
 
-  @moduledoc """
-  Scaffolds a new inbound router module.
+    @moduledoc """
+    Scaffolds a new inbound router module.
 
-  The generated module declares `use MailglassInbound.Router` and a single
-  sample `route/2` so the file compiles and serves as a copy-edit starting
-  point. Add real routes with `mix mailglass.gen.inbound_route` or by editing
-  the file directly.
+    The generated module declares `use MailglassInbound.Router` and a single
+    sample `route/2` so the file compiles and serves as a copy-edit starting
+    point. Add real routes with `mix mailglass.gen.inbound_route` or by editing
+    the file directly.
 
-  ## Examples
+    ## Examples
 
-      mix mailglass.gen.inbound_router InboundRouter
-      mix mailglass.gen.inbound_router MyApp.InboundRouter
+        mix mailglass.gen.inbound_router InboundRouter
+        mix mailglass.gen.inbound_router MyApp.InboundRouter
 
-  `--dry-run` is supported as the framework-provided global switch (it is *not*
-  in this task's option schema); it previews the diff and writes nothing.
-  """
-
-  use Boundary, classify_to: Mailglass
-  use Igniter.Mix.Task
-
-  @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
-    %Igniter.Mix.Task.Info{
-      schema: [],
-      positional: [:router]
-    }
-  end
-
-  @impl Igniter.Mix.Task
-  def igniter(igniter) do
-    router_arg = igniter.args.positional.router
-    app_module = Igniter.Project.Application.app_module(igniter) || Test
-
-    module_name =
-      if String.contains?(router_arg, ".") do
-        Module.concat([router_arg])
-      else
-        Module.concat([app_module, router_arg])
-      end
-
-    Igniter.Project.Module.create_module(igniter, module_name, router_body())
-  end
-
-  defp router_body do
+    `--dry-run` is supported as the framework-provided global switch (it is *not*
+    in this task's option schema); it previews the diff and writes nothing.
     """
-    use MailglassInbound.Router
 
-    # Routes are matched top-to-bottom, first-match-wins. Replace this sample
-    # route with your own, or add more with `mix mailglass.gen.inbound_route`.
-    #
-    # `SampleMailbox` is a PLACEHOLDER — it points at a module that does not
-    # exist yet. Routing only stores the alias as an atom, so this file compiles,
-    # but the route resolves to nothing until you create the mailbox (e.g. with
-    # `mix mailglass.gen.mailbox MyApp.Inbound.Support`) and rename the route.
-    route SampleMailbox, recipient: "support@example.com"
-    """
+    use Boundary, classify_to: Mailglass
+    use Igniter.Mix.Task
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        schema: [],
+        positional: [:router]
+      }
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      router_arg = igniter.args.positional.router
+      app_module = Igniter.Project.Application.app_module(igniter) || Test
+
+      module_name =
+        if String.contains?(router_arg, ".") do
+          Module.concat([router_arg])
+        else
+          Module.concat([app_module, router_arg])
+        end
+
+      Igniter.Project.Module.create_module(igniter, module_name, router_body())
+    end
+
+    defp router_body do
+      """
+      use MailglassInbound.Router
+
+      # Routes are matched top-to-bottom, first-match-wins. Replace this sample
+      # route with your own, or add more with `mix mailglass.gen.inbound_route`.
+      #
+      # `SampleMailbox` is a PLACEHOLDER — it points at a module that does not
+      # exist yet. Routing only stores the alias as an atom, so this file compiles,
+      # but the route resolves to nothing until you create the mailbox (e.g. with
+      # `mix mailglass.gen.mailbox MyApp.Inbound.Support`) and rename the route.
+      route SampleMailbox, recipient: "support@example.com"
+      """
+    end
   end
 end

--- a/lib/mix/tasks/mailglass.gen.mailable.ex
+++ b/lib/mix/tasks/mailglass.gen.mailable.ex
@@ -1,62 +1,70 @@
-defmodule Mix.Tasks.Mailglass.Gen.Mailable do
-  @moduledoc """
-  Scaffolds a new Mailable module and its associated HEEx template.
+# Compile-guarded on Igniter (an optional dep) so a fresh mailglass install
+# stays HTTP-client-agnostic. Igniter pulls req/finch/mint; gating the module
+# on `Code.ensure_loaded?(Igniter.Mix.Task)` keeps consumers who don't run
+# this generator from carrying that chain, and keeps the
+# `mix compile --no-optional-deps` lane green. Mirrors the Oban guard in
+# `Mailglass.Oban.TenancyMiddleware`. Adopters add Igniter to run this task.
+if Code.ensure_loaded?(Igniter.Mix.Task) do
+  defmodule Mix.Tasks.Mailglass.Gen.Mailable do
+    @moduledoc """
+    Scaffolds a new Mailable module and its associated HEEx template.
 
-  ## Examples
+    ## Examples
 
-      mix mailglass.gen.mailable Notification
-      mix mailglass.gen.mailable MyApp.Mail.Welcome
-  """
-  use Boundary, classify_to: Mailglass
-  use Igniter.Mix.Task
-
-  @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
-    %Igniter.Mix.Task.Info{
-      schema: [],
-      positional: [:mailable]
-    }
-  end
-
-  @impl Igniter.Mix.Task
-  def igniter(igniter) do
-    mailable_arg = igniter.args.positional.mailable
-    app_module = Igniter.Project.Application.app_module(igniter) || Test
-
-    module_name =
-      if String.contains?(mailable_arg, ".") do
-        Module.concat([mailable_arg])
-      else
-        Module.concat([app_module, "Mail", mailable_arg])
-      end
-
-    mailable_basename = module_name |> Module.split() |> List.last()
-    lowercase_name = mailable_basename |> Macro.underscore()
-
-    module_code = """
-      use Mailglass.Mailable, stream: :transactional
-      import Phoenix.Component
-
-      embed_templates "#{lowercase_name}/*"
-
-      def #{lowercase_name}(assigns \\\\ []) do
-        new()
-        |> Mailglass.Message.subject("#{mailable_basename}")
-        |> Mailglass.Message.html_body(#{lowercase_name}_template(assigns))
-        |> Mailglass.Message.put_function(:#{lowercase_name})
-      end
+        mix mailglass.gen.mailable Notification
+        mix mailglass.gen.mailable MyApp.Mail.Welcome
     """
+    use Boundary, classify_to: Mailglass
+    use Igniter.Mix.Task
 
-    module_path = Igniter.Project.Module.proper_location(igniter, module_name)
-    module_dir = Path.rootname(module_path)
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        schema: [],
+        positional: [:mailable]
+      }
+    end
 
-    template_path = Path.join(module_dir, "#{lowercase_name}_template.html.heex")
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      mailable_arg = igniter.args.positional.mailable
+      app_module = Igniter.Project.Application.app_module(igniter) || Test
 
-    template_code =
-      "<Mailglass.Components.heading>#{mailable_basename}</Mailglass.Components.heading>\n"
+      module_name =
+        if String.contains?(mailable_arg, ".") do
+          Module.concat([mailable_arg])
+        else
+          Module.concat([app_module, "Mail", mailable_arg])
+        end
 
-    igniter
-    |> Igniter.Project.Module.create_module(module_name, module_code)
-    |> Igniter.create_new_file(template_path, template_code)
+      mailable_basename = module_name |> Module.split() |> List.last()
+      lowercase_name = mailable_basename |> Macro.underscore()
+
+      module_code = """
+        use Mailglass.Mailable, stream: :transactional
+        import Phoenix.Component
+
+        embed_templates "#{lowercase_name}/*"
+
+        def #{lowercase_name}(assigns \\\\ []) do
+          new()
+          |> Mailglass.Message.subject("#{mailable_basename}")
+          |> Mailglass.Message.html_body(#{lowercase_name}_template(assigns))
+          |> Mailglass.Message.put_function(:#{lowercase_name})
+        end
+      """
+
+      module_path = Igniter.Project.Module.proper_location(igniter, module_name)
+      module_dir = Path.rootname(module_path)
+
+      template_path = Path.join(module_dir, "#{lowercase_name}_template.html.heex")
+
+      template_code =
+        "<Mailglass.Components.heading>#{mailable_basename}</Mailglass.Components.heading>\n"
+
+      igniter
+      |> Igniter.Project.Module.create_module(module_name, module_code)
+      |> Igniter.create_new_file(template_path, template_code)
+    end
   end
 end

--- a/lib/mix/tasks/mailglass.gen.mailbox.ex
+++ b/lib/mix/tasks/mailglass.gen.mailbox.ex
@@ -1,138 +1,146 @@
-defmodule Mix.Tasks.Mailglass.Gen.Mailbox do
-  @shortdoc "Scaffolds an inbound mailbox, a route stub, and a MailboxCase test stub"
+# Compile-guarded on Igniter (an optional dep) so a fresh mailglass install
+# stays HTTP-client-agnostic. Igniter pulls req/finch/mint; gating the module
+# on `Code.ensure_loaded?(Igniter.Mix.Task)` keeps consumers who don't run
+# this generator from carrying that chain, and keeps the
+# `mix compile --no-optional-deps` lane green. Mirrors the Oban guard in
+# `Mailglass.Oban.TenancyMiddleware`. Adopters add Igniter to run this task.
+if Code.ensure_loaded?(Igniter.Mix.Task) do
+  defmodule Mix.Tasks.Mailglass.Gen.Mailbox do
+    @shortdoc "Scaffolds an inbound mailbox, a route stub, and a MailboxCase test stub"
 
-  @moduledoc """
-  Scaffolds an inbound mailbox and wires it into your router.
+    @moduledoc """
+    Scaffolds an inbound mailbox and wires it into your router.
 
-  Generates three things:
+    Generates three things:
 
-    1. A mailbox module implementing `MailglassInbound.Mailbox` with a default
-       `process/1` that returns the neutral `:accept` outcome.
-    2. A route stub in the configured router, inserted idempotently via the same
-       helper that backs `mix mailglass.gen.inbound_route`.
-    3. An ExUnit test stub that `use MailglassInbound.MailboxCase`.
+      1. A mailbox module implementing `MailglassInbound.Mailbox` with a default
+         `process/1` that returns the neutral `:accept` outcome.
+      2. A route stub in the configured router, inserted idempotently via the same
+         helper that backs `mix mailglass.gen.inbound_route`.
+      3. An ExUnit test stub that `use MailglassInbound.MailboxCase`.
 
-  If the configured router module is not found, an actionable notice is emitted
-  instead of auto-creating one — run `mix mailglass.gen.inbound_router` first.
+    If the configured router module is not found, an actionable notice is emitted
+    instead of auto-creating one — run `mix mailglass.gen.inbound_router` first.
 
-  ## Examples
+    ## Examples
 
-      mix mailglass.gen.mailbox MyApp.Inbound.Support
-      mix mailglass.gen.mailbox MyApp.Inbound.Support --recipient support@example.com
-      mix mailglass.gen.mailbox MyApp.Inbound.Support --router MyApp.InboundRouter
+        mix mailglass.gen.mailbox MyApp.Inbound.Support
+        mix mailglass.gen.mailbox MyApp.Inbound.Support --recipient support@example.com
+        mix mailglass.gen.mailbox MyApp.Inbound.Support --router MyApp.InboundRouter
 
-  ## Positional arguments
+    ## Positional arguments
 
-    * `mailbox` - the mailbox module to create.
+      * `mailbox` - the mailbox module to create.
 
-  ## Options
+    ## Options
 
-    * `--router` - the router to add the route stub to. Defaults to `<App>.InboundRouter`.
-    * `--recipient` - the recipient matcher for the route stub. Defaults to
-      `<underscored-mailbox-name>@example.com`.
+      * `--router` - the router to add the route stub to. Defaults to `<App>.InboundRouter`.
+      * `--recipient` - the recipient matcher for the route stub. Defaults to
+        `<underscored-mailbox-name>@example.com`.
 
-  `--dry-run` is supported as the framework-provided global switch (it is *not*
-  in this task's option schema); it previews the diff and writes nothing.
-  """
+    `--dry-run` is supported as the framework-provided global switch (it is *not*
+    in this task's option schema); it previews the diff and writes nothing.
+    """
 
-  use Boundary, classify_to: Mailglass
-  use Igniter.Mix.Task
+    use Boundary, classify_to: Mailglass
+    use Igniter.Mix.Task
 
-  alias Mix.Tasks.Mailglass.Gen.InboundRoute
+    alias Mix.Tasks.Mailglass.Gen.InboundRoute
 
-  @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
-    %Igniter.Mix.Task.Info{
-      schema: [router: :string, recipient: :string],
-      positional: [:mailbox]
-    }
-  end
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        schema: [router: :string, recipient: :string],
+        positional: [:mailbox]
+      }
+    end
 
-  @impl Igniter.Mix.Task
-  def igniter(igniter) do
-    mailbox_arg = igniter.args.positional.mailbox
-    options = igniter.args.options
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      mailbox_arg = igniter.args.positional.mailbox
+      options = igniter.args.options
 
-    mailbox = InboundRoute.parse_module(mailbox_arg)
-    router = InboundRoute.router_module(igniter, options[:router])
-    recipient = options[:recipient] || default_recipient(mailbox)
+      mailbox = InboundRoute.parse_module(mailbox_arg)
+      router = InboundRoute.router_module(igniter, options[:router])
+      recipient = options[:recipient] || default_recipient(mailbox)
 
-    # Resolve the test-file location from the source location BEFORE creating
-    # the module so ordering against `create_module/3` cannot perturb the path.
-    test_path =
+      # Resolve the test-file location from the source location BEFORE creating
+      # the module so ordering against `create_module/3` cannot perturb the path.
+      test_path =
+        igniter
+        |> Igniter.Project.Module.proper_location(mailbox, :source_folder)
+        |> String.replace_prefix("lib/", "test/")
+        |> String.replace_suffix(".ex", "_test.exs")
+
+      test_module = test_module(mailbox)
+
       igniter
-      |> Igniter.Project.Module.proper_location(mailbox, :source_folder)
-      |> String.replace_prefix("lib/", "test/")
-      |> String.replace_suffix(".ex", "_test.exs")
+      |> Igniter.Project.Module.create_module(mailbox, mailbox_body())
+      |> Igniter.create_new_file(test_path, test_stub_body(test_module, mailbox, router))
+      # Reuse the shared idempotent add-route helper (route stub). When the router
+      # is missing, the helper emits the actionable "run gen.inbound_router" notice.
+      |> InboundRoute.add_route(router, mailbox, recipient: recipient)
+    end
 
-    test_module = test_module(mailbox)
-
-    igniter
-    |> Igniter.Project.Module.create_module(mailbox, mailbox_body())
-    |> Igniter.create_new_file(test_path, test_stub_body(test_module, mailbox, router))
-    # Reuse the shared idempotent add-route helper (route stub). When the router
-    # is missing, the helper emits the actionable "run gen.inbound_router" notice.
-    |> InboundRoute.add_route(router, mailbox, recipient: recipient)
-  end
-
-  # Conventional ExUnit test-module name: suffix `Test` on the LAST segment
-  # (`Foo.Bar` -> `Foo.BarTest`), which keeps igniter from relocating the file
-  # into a nested `bar/test.exs` based on a `Foo.Bar.Test` module name.
-  defp test_module(mailbox) do
-    mailbox
-    |> Module.split()
-    |> List.update_at(-1, &(&1 <> "Test"))
-    |> Module.concat()
-  end
-
-  defp default_recipient(mailbox) do
-    name =
+    # Conventional ExUnit test-module name: suffix `Test` on the LAST segment
+    # (`Foo.Bar` -> `Foo.BarTest`), which keeps igniter from relocating the file
+    # into a nested `bar/test.exs` based on a `Foo.Bar.Test` module name.
+    defp test_module(mailbox) do
       mailbox
       |> Module.split()
-      |> List.last()
-      |> Macro.underscore()
-
-    "#{name}@example.com"
-  end
-
-  defp mailbox_body do
-    """
-    @behaviour MailglassInbound.Mailbox
-
-    @impl MailglassInbound.Mailbox
-    def process(%MailglassInbound.InboundMessage{} = _message) do
-      # Inspect the message and return one of the locked mailbox outcomes:
-      # :accept | :ignore | {:reject, reason} | {:bounce, reason}.
-      :accept
+      |> List.update_at(-1, &(&1 <> "Test"))
+      |> Module.concat()
     end
-    """
-  end
 
-  defp test_stub_body(test_module, _mailbox, router) do
-    """
-    defmodule #{inspect(test_module)} do
-      use MailglassInbound.MailboxCase
+    defp default_recipient(mailbox) do
+      name =
+        mailbox
+        |> Module.split()
+        |> List.last()
+        |> Macro.underscore()
 
-      # MailboxCase imports TestAssertions and aliases Fixtures / Test, builds an
-      # %InboundMessage{} fixture, drives the real persist + route + execute path
-      # via Test.Ingress, and asserts the captured outcome. Replace the body with
-      # assertions for your routing and process/1 behavior.
-      test "accepts an inbound message" do
-        # Route through your compiled router (the `route` stub this task added to
-        # #{inspect(router)}) via the `:router` option — the same `use
-        # MailglassInbound.Router` module your endpoint mounts. Build a message
-        # whose envelope_recipient matches the route's recipient matcher.
-        #
-        # message = Fixtures.build_inbound_message(subject: "hi")
-        #
-        # {:ok, _} =
-        #   Test.Ingress.receive_inbound(message, router: #{inspect(router)})
-        #
-        # # Each assert_inbound_* consumes ONE captured tuple, so drive one
-        # # message per assertion.
-        # assert_inbound_accepted()
+      "#{name}@example.com"
+    end
+
+    defp mailbox_body do
+      """
+      @behaviour MailglassInbound.Mailbox
+
+      @impl MailglassInbound.Mailbox
+      def process(%MailglassInbound.InboundMessage{} = _message) do
+        # Inspect the message and return one of the locked mailbox outcomes:
+        # :accept | :ignore | {:reject, reason} | {:bounce, reason}.
+        :accept
       end
+      """
     end
-    """
+
+    defp test_stub_body(test_module, _mailbox, router) do
+      """
+      defmodule #{inspect(test_module)} do
+        use MailglassInbound.MailboxCase
+
+        # MailboxCase imports TestAssertions and aliases Fixtures / Test, builds an
+        # %InboundMessage{} fixture, drives the real persist + route + execute path
+        # via Test.Ingress, and asserts the captured outcome. Replace the body with
+        # assertions for your routing and process/1 behavior.
+        test "accepts an inbound message" do
+          # Route through your compiled router (the `route` stub this task added to
+          # #{inspect(router)}) via the `:router` option — the same `use
+          # MailglassInbound.Router` module your endpoint mounts. Build a message
+          # whose envelope_recipient matches the route's recipient matcher.
+          #
+          # message = Fixtures.build_inbound_message(subject: "hi")
+          #
+          # {:ok, _} =
+          #   Test.Ingress.receive_inbound(message, router: #{inspect(router)})
+          #
+          # # Each assert_inbound_* consumes ONE captured tuple, so drive one
+          # # message per assertion.
+          # assert_inbound_accepted()
+        end
+      end
+      """
+    end
   end
 end

--- a/lib/mix/tasks/mailglass.upgrade.v0_2.ex
+++ b/lib/mix/tasks/mailglass.upgrade.v0_2.ex
@@ -1,89 +1,98 @@
 # credo:disable-for-this-file Credo.Check.Readability.ModuleNames
-defmodule Mix.Tasks.Mailglass.Upgrade.V0_2 do
-  use Boundary, classify_to: Mailglass
 
-  @migration_guide_url "https://hexdocs.pm/mailglass/guides/upgrading-to-v1_0.html"
+# Compile-guarded on Igniter so a fresh `mix mailglass.install` stays
+# HTTP-client-agnostic: Igniter is an optional dep (it pulls req/finch/mint),
+# so consumers who don't run this codemod never compile this module. Mirrors
+# the `Mailglass.Oban.TenancyMiddleware` Oban guard. When Igniter is absent the
+# whole task (including its Sourceror/Igniter references) is elided, keeping the
+# `mix compile --no-optional-deps --warnings-as-errors` lane green.
+if Code.ensure_loaded?(Igniter.Mix.Task) do
+  defmodule Mix.Tasks.Mailglass.Upgrade.V0_2 do
+    use Boundary, classify_to: Mailglass
 
-  @shortdoc "Transitional codemod for the Mailglass.Message setter upgrade path"
+    @migration_guide_url "https://hexdocs.pm/mailglass/guides/upgrading-to-v1_0.html"
 
-  @moduledoc """
-  Transitional codemod that upgrades adopter code from raw `Swoosh.Email`
-  usage to native `Mailglass.Message` setters.
+    @shortdoc "Transitional codemod for the Mailglass.Message setter upgrade path"
 
-  Use this task as one step in the canonical `0.x -> 1.0` migration path, not
-  as the whole compatibility contract by itself. The authoritative guide lives
-  at `guides/upgrading-to-v1_0.md`.
+    @moduledoc """
+    Transitional codemod that upgrades adopter code from raw `Swoosh.Email`
+    usage to native `Mailglass.Message` setters.
 
-  ## Options
+    Use this task as one step in the canonical `0.x -> 1.0` migration path, not
+    as the whole compatibility contract by itself. The authoritative guide lives
+    at `guides/upgrading-to-v1_0.md`.
 
-    * `--apply` - actually apply the changes to the files. Default is a dry-run.
-  """
+    ## Options
 
-  use Igniter.Mix.Task
+      * `--apply` - actually apply the changes to the files. Default is a dry-run.
+    """
 
-  @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
-    %Igniter.Mix.Task.Info{
-      schema: [apply: :boolean],
-      aliases: [a: :apply]
-    }
-  end
+    use Igniter.Mix.Task
 
-  @impl Igniter.Mix.Task
-  def igniter(igniter) do
-    # Force dry-run if --apply is not passed
-    igniter =
-      if igniter.args.options[:apply] do
-        igniter
-      else
-        Igniter.assign(igniter, :dry_run?, true)
-      end
-
-    Igniter.update_all_elixir_files(igniter, &upgrade_swoosh_calls/1)
-  end
-
-  defp upgrade_swoosh_calls(zipper) do
-    pred = fn z ->
-      node = Sourceror.Zipper.node(z)
-      # Skip strings
-      if Igniter.Code.String.string?(z) do
-        false
-      else
-        case node do
-          {{:., _, [{:__aliases__, _, [:Swoosh, :Email]}, fun]}, _, _} when is_atom(fun) -> true
-          _ -> false
-        end
-      end
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        schema: [apply: :boolean],
+        aliases: [a: :apply]
+      }
     end
 
-    fun = fn z ->
-      node = Sourceror.Zipper.node(z)
-      {{:., meta1, [{:__aliases__, _meta2, [:Swoosh, :Email]}, function_name]}, _meta3, args} = node
-
-      new_node =
-        case function_name do
-          f when f in [:to, :from, :subject, :text_body, :html_body, :header, :put_tag] ->
-            {f, meta1, args}
-
-          :attachment ->
-            {:attach, meta1, args}
-
-          _ ->
-            IO.warn(
-              "Skipping unknown Swoosh.Email function: #{function_name}/#{length(args || [])}. " <>
-                "Review #{@migration_guide_url} for ambiguous-case migration guidance and " <>
-                "the Mailglass.Message.update_swoosh/2 escape hatch."
-            )
-
-            node
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      # Force dry-run if --apply is not passed
+      igniter =
+        if igniter.args.options[:apply] do
+          igniter
+        else
+          Igniter.assign(igniter, :dry_run?, true)
         end
 
-      {:ok, Sourceror.Zipper.replace(z, new_node)}
+      Igniter.update_all_elixir_files(igniter, &upgrade_swoosh_calls/1)
     end
 
-    case Igniter.Code.Common.update_all_matches(zipper, pred, fun) do
-      {:ok, new_zipper} -> {:ok, new_zipper}
-      :error -> {:ok, zipper}
+    defp upgrade_swoosh_calls(zipper) do
+      pred = fn z ->
+        node = Sourceror.Zipper.node(z)
+        # Skip strings
+        if Igniter.Code.String.string?(z) do
+          false
+        else
+          case node do
+            {{:., _, [{:__aliases__, _, [:Swoosh, :Email]}, fun]}, _, _} when is_atom(fun) -> true
+            _ -> false
+          end
+        end
+      end
+
+      fun = fn z ->
+        node = Sourceror.Zipper.node(z)
+        {{:., meta1, [{:__aliases__, _meta2, [:Swoosh, :Email]}, function_name]}, _meta3, args} = node
+
+        new_node =
+          case function_name do
+            f when f in [:to, :from, :subject, :text_body, :html_body, :header, :put_tag] ->
+              {f, meta1, args}
+
+            :attachment ->
+              {:attach, meta1, args}
+
+            _ ->
+              IO.warn(
+                "Skipping unknown Swoosh.Email function: #{function_name}/#{length(args || [])}. " <>
+                  "Review #{@migration_guide_url} for ambiguous-case migration guidance and " <>
+                  "the Mailglass.Message.update_swoosh/2 escape hatch."
+              )
+
+              node
+          end
+
+        {:ok, Sourceror.Zipper.replace(z, new_node)}
+      end
+
+      case Igniter.Code.Common.update_all_matches(zipper, pred, fun) do
+        {:ok, new_zipper} -> {:ok, new_zipper}
+        :error -> {:ok, zipper}
+      end
     end
   end
 end

--- a/lib/mix/tasks/mailglass.upgrade.v0_2.ex
+++ b/lib/mix/tasks/mailglass.upgrade.v0_2.ex
@@ -66,7 +66,9 @@ if Code.ensure_loaded?(Igniter.Mix.Task) do
 
       fun = fn z ->
         node = Sourceror.Zipper.node(z)
-        {{:., meta1, [{:__aliases__, _meta2, [:Swoosh, :Email]}, function_name]}, _meta3, args} = node
+
+        {{:., meta1, [{:__aliases__, _meta2, [:Swoosh, :Email]}, function_name]}, _meta3, args} =
+          node
 
         new_node =
           case function_name do

--- a/mailglass_inbound/mix.exs
+++ b/mailglass_inbound/mix.exs
@@ -27,7 +27,11 @@ defmodule MailglassInbound.MixProject do
   def application do
     [
       mod: {MailglassInbound.Application, []},
-      extra_applications: [:logger]
+      # :inets/:ssl back the SES SigningCertURL fetch (`:httpc` GET over HTTPS in
+      # ingress/providers/ses.ex). Declared explicitly rather than relying on a
+      # transitive load (core's Igniter chain provided :inets before it became
+      # an optional dep).
+      extra_applications: [:logger, :inets, :ssl]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -167,9 +167,13 @@ defmodule Mailglass.MixProject do
       {:lazy_html, ">= 0.1.0", only: :test},
       {:phoenix_live_reload, "~> 1.6", optional: true, only: [:dev, :test]},
       # Dev/test
-      # Public upgrade codemod task ships in the package, so Igniter must be
-      # available when consumer apps compile mailglass as a dependency.
-      {:igniter, "~> 0.7", runtime: false},
+      # Optional: the public `mix mailglass.upgrade.v0_2` codemod is built on
+      # Igniter, but the module is compile-guarded with
+      # `Code.ensure_loaded?(Igniter.Mix.Task)`, so consumers who don't run it
+      # don't carry Igniter (and its `req`/`finch`/`mint` chain) in their lock —
+      # keeping a fresh install HTTP-client-agnostic (OPS-01). Adopters running
+      # the codemod add Igniter themselves (`mix igniter.install` / deps entry).
+      {:igniter, "~> 0.7", optional: true, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.40", only: :dev, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,11 @@ defmodule Mailglass.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :crypto, :public_key],
+      # :inets/:ssl back the SES SNS SigningCertURL fetch (`:httpc` GET over
+      # HTTPS in webhook/providers/ses.ex). Declared explicitly rather than
+      # relying on a transitive load — Igniter is now an optional dep, so it no
+      # longer drags :inets into a consumer's app tree.
+      extra_applications: [:logger, :crypto, :public_key, :inets, :ssl],
       mod: {Mailglass.Application, []}
     ]
   end


### PR DESCRIPTION
## Problem

After the swoosh-1.26 install-crash fix (#55) shipped in 1.4.3, the consumer-install smoke reached the **OPS-01 guard** for the first time and failed:

```
OPS-01 failed: fresh --no-mailer published install resolved hackney or finch in mix.lock.
```

**Root cause (pre-existing, independent of swoosh):** core declared `{:igniter, "~> 0.7", runtime: false}` for the Igniter-based `mix mailglass.gen.*` / `mailglass.upgrade.v0_2` tasks, and `igniter → req → finch → mint`. `runtime: false` keeps it out of the *running* app but still locks + compiles it, so every adopter's `mix.lock` carried an HTTP client — exactly what OPS-01 forbids (mailglass leaves the Swoosh API client to the adopter, defaulting `:api_client` to `false`). It would have failed identically for 1.4.2; the install just crashed before reaching the guard.

## Fix

Make igniter `optional: true` and compile-guard all **five** Igniter-based task modules with `Code.ensure_loaded?(Igniter.Mix.Task)` — mirroring the existing `Mailglass.Oban.TenancyMiddleware` Oban guard:

- `mailglass.gen.mailable`, `mailglass.gen.mailbox`, `mailglass.gen.inbound_route`, `mailglass.gen.inbound_router`, `mailglass.upgrade.v0_2`

Consumers who don't run those tasks no longer carry `igniter`/`req`/`finch`/`mint`, and the `Compile No Optional Deps` lane stays green (the modules elide when igniter is absent). Adopters add igniter themselves to run the generators/codemod — the same pattern `guides/upgrading-from-v0_1.md` already documents.

## Verification (local)

| Check | Result |
|---|---|
| `mix compile --warnings-as-errors` (igniter present) | ✅ all 5 tasks compile |
| `mix compile --no-optional-deps --warnings-as-errors` (igniter absent) | ✅ all 5 tasks elided, clean |
| path-dep consumer `mix deps.get` | ✅ no finch/hackney/req/igniter/mint in lock; swoosh/ecto/plug present |
| `mix test test/mix/` + upgrade test | ✅ 42 tests, 0 failures |
| `mix credo --strict` (5 files) | ✅ no issues |

The consumer-install smoke (incl. OPS-01) will validate end-to-end on the next `release: published`. Closes the remaining OPS-01 leg of #32 (the swoosh crash leg shipped in 1.4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)