### PR TITLE
test(installer): compile the installer's generated output (close the codegen gap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,38 @@ jobs:
       - name: Compile without optional deps
         run: mix compile --no-optional-deps --warnings-as-errors
 
+  installer_host_smoke:
+    name: Installer Host Smoke (Advisory)
+    runs-on: ubuntu-latest
+    # Shift-left of the post-publish consumer-install smoke: runs the SAME
+    # scripts/consumer_install_smoke.sh against the WORKING TREE (local path
+    # deps) — phx.new -> install -> OPS-01 guard -> compile --warnings-as-errors
+    # -> boot -> GET /dev/mail/. Catches installer codegen / compile / runtime /
+    # boot regressions on the PR instead of after publishing (the gap that let
+    # the 1.4.3-1.4.5 install bug stack ship). The fast in-process counterpart is
+    # test/mailglass/install/install_compile_test.exs.
+    #
+    # Advisory for now: phx.new + the sandbox's own deps.get + server boot are
+    # network-dependent and slower than the required lanes. Promote to a required
+    # context (drop continue-on-error; add to scripts/setup_branch_protection.sh)
+    # once it has proven stable.
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Set up OTP + Elixir
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93  # v1.24.0
+        with:
+          elixir-version: "1.18"
+          otp-version: "27"
+      - name: Consumer install smoke (working tree, local path deps)
+        env:
+          DEP_MODE: path
+          MAILGLASS_PATH: ${{ github.workspace }}
+          WORK_DIR: ${{ runner.temp }}
+        run: bash scripts/consumer_install_smoke.sh
+
   support_contract_core:
     name: Support Contract Core (Elixir 1.18 / OTP 27)
     runs-on: ubuntu-latest

--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -338,10 +338,6 @@ jobs:
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-      - name: Install hex + rebar
-        run: |
-          mix local.hex --force
-          mix local.rebar --force
       - name: Check published inbound compatibility
         id: inbound-compat
         env:
@@ -364,99 +360,17 @@ jobs:
             echo "include_inbound=false" >> "$GITHUB_OUTPUT"
             echo "Skipping inbound consumer dependency: mailglass_inbound ${VERSION_INBOUND} is not compatible with mailglass ${VERSION}."
           fi
-      - name: Install phx_new archive
-        run: mix archive.install hex phx_new --force
-      - name: Generate Phoenix host project
-        working-directory: ${{ runner.temp }}
-        run: |
-          mix phx.new sandbox --module Sandbox --app sandbox --no-ecto --no-mailer --install
-      - name: Add mailglass deps
-        working-directory: ${{ runner.temp }}/sandbox
+      - name: Run consumer-install smoke (published Hex versions)
+        # Shared body with the PR-time `Installer Host Smoke` job in ci.yml —
+        # phx.new -> install -> OPS-01 guard -> compile --warnings-as-errors ->
+        # boot -> GET /dev/mail/. Here DEP_MODE=hex pins the published versions.
         env:
+          DEP_MODE: hex
+          WORK_DIR: ${{ runner.temp }}
           VERSION: ${{ needs.cron-guard.outputs.version }}
           VERSION_INBOUND: ${{ needs.cron-guard.outputs.version_inbound }}
           INCLUDE_INBOUND: ${{ steps.inbound-compat.outputs.include_inbound }}
-        run: |
-          elixir -e '
-            version = System.get_env("VERSION")
-            version_inbound = System.get_env("VERSION_INBOUND")
-            include_inbound = System.get_env("INCLUDE_INBOUND") == "true"
-            mix_path = "mix.exs"
-            content = File.read!(mix_path)
-            inbound_entry =
-              if include_inbound && version_inbound && version_inbound != "" do
-                "      {:mailglass_inbound, \"== #{version_inbound}\"},\n"
-              else
-                ""
-              end
-            entries = "      {:mailglass, \"== #{version}\"},\n      {:mailglass_admin, \"== #{version}\"},\n" <> inbound_entry
-            updated = String.replace(content, ~r/(defp deps do\n\s*\[\n)/, "\\1" <> entries, global: false)
-            File.write!(mix_path, updated)
-          '
-          grep -F "mailglass" mix.exs
-      - name: mix deps.get
-        working-directory: ${{ runner.temp }}/sandbox
-        run: mix deps.get
-      - name: Run mix mailglass.install
-        working-directory: ${{ runner.temp }}/sandbox
-        run: mix mailglass.install
-      - name: Guard against hackney/api_client regression on published install
-        working-directory: ${{ runner.temp }}/sandbox
-        run: |
-          set -euo pipefail
-
-          if ! grep -F "config :swoosh, :api_client, false" config/runtime.exs; then
-            echo "OPS-01 failed: generated runtime.exs is missing config :swoosh, :api_client, false."
-            exit 1
-          fi
-
-          if grep -Eq '^[[:space:]]*config :swoosh, :api_client, Swoosh\.ApiClient\.Finch([[:space:]]|$)' config/runtime.exs; then
-            echo "OPS-01 failed: generated runtime.exs contains an uncommented Swoosh.ApiClient.Finch line."
-            exit 1
-          fi
-
-          if grep -Eq '"(hackney|finch)":' mix.lock; then
-            echo "OPS-01 failed: fresh --no-mailer published install resolved hackney or finch in mix.lock."
-            exit 1
-          fi
-
-          echo "OPS-01 guard passed."
-      - name: Compile, fail on warnings
-        working-directory: ${{ runner.temp }}/sandbox
-        run: |
-          set -o pipefail
-          mix compile --warnings-as-errors 2>&1 | tee compile.log
-          if grep -F "UndefinedFunctionError" compile.log; then
-            echo "Smoke failed: UndefinedFunctionError detected in compile output (literal G-1 regression on published artifact)."
-            exit 1
-          fi
-      - name: Boot endpoint and curl /dev/mail/
-        working-directory: ${{ runner.temp }}/sandbox
-        env:
-          MIX_ENV: dev
-        run: |
-          mix phx.server &
-          SERVER_PID=$!
-          # shellcheck disable=SC2064
-          trap "kill $SERVER_PID 2>/dev/null || true" EXIT
-
-          DEADLINE=$(( SECONDS + 30 ))
-          until curl -fsI http://localhost:4000/dev/mail/ >/dev/null 2>&1; do
-            if [ $SECONDS -ge $DEADLINE ]; then
-              echo "Smoke failed: endpoint did not respond on /dev/mail/ within 30s."
-              kill $SERVER_PID 2>/dev/null || true
-              exit 1
-            fi
-            sleep 2
-          done
-
-          STATUS=$(curl -fs -o /dev/null -w "%{http_code}" http://localhost:4000/dev/mail/)
-          echo "GET /dev/mail/ → HTTP ${STATUS}"
-          if [ "${STATUS}" != "200" ]; then
-            echo "Smoke failed: /dev/mail/ returned ${STATUS}, expected 200."
-            exit 1
-          fi
-          echo "Endpoint smoke passed."
+        run: bash scripts/consumer_install_smoke.sh
 
   published-trust-journey:
     name: Published-version trust journey

--- a/scripts/consumer_install_smoke.sh
+++ b/scripts/consumer_install_smoke.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Consumer-install smoke — the canonical "does a fresh adopter install actually
+# work" gate. Generates a fresh Phoenix host, installs mailglass, guards OPS-01,
+# compiles with --warnings-as-errors, boots the endpoint, and asserts
+# GET /dev/mail/ == 200.
+#
+# Parameterized by DEP_MODE so ONE body backs two callers:
+#   * DEP_MODE=path — PR-time CI against the working tree (local path deps).
+#                     Catches codegen/compile/runtime/boot regressions BEFORE
+#                     merge. Requires MAILGLASS_PATH (repo root).
+#   * DEP_MODE=hex  — post-publish smoke against published Hex versions.
+#                     Requires VERSION; optional VERSION_INBOUND + INCLUDE_INBOUND.
+#
+# Optional: WORK_DIR (defaults to a fresh mktemp dir) — where `sandbox/` is built.
+#
+# The repo-local fast guard (test/mailglass/install/install_compile_test.exs)
+# parses/compiles each generated artifact in-process; THIS script is the full
+# real-compile + boot integration backstop.
+set -euo pipefail
+
+DEP_MODE="${DEP_MODE:-path}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
+SANDBOX="${WORK_DIR}/sandbox"
+
+mkdir -p "${WORK_DIR}"
+
+echo "==> consumer-install smoke (DEP_MODE=${DEP_MODE}, WORK_DIR=${WORK_DIR})"
+
+mix local.hex --force
+mix local.rebar --force
+mix archive.install hex phx_new --force
+
+rm -rf "${SANDBOX}"
+( cd "${WORK_DIR}" && mix phx.new sandbox --module Sandbox --app sandbox --no-ecto --no-mailer --install )
+
+cd "${SANDBOX}"
+
+# --- inject the mailglass deps into the generated host mix.exs -----------------
+# Build the entries inside Elixir (no fragile shell \n escaping); the values come
+# in via env so both modes share one regex insertion after `defp deps do\n  [`.
+DEP_MODE="${DEP_MODE}" \
+MAILGLASS_PATH="${MAILGLASS_PATH:-}" \
+VERSION="${VERSION:-}" \
+VERSION_INBOUND="${VERSION_INBOUND:-}" \
+INCLUDE_INBOUND="${INCLUDE_INBOUND:-false}" \
+elixir -e '
+  entries =
+    case System.get_env("DEP_MODE") do
+      "path" ->
+        mg = System.get_env("MAILGLASS_PATH") || raise "path mode requires MAILGLASS_PATH"
+        ~s(      {:mailglass, path: "#{mg}", override: true},\n) <>
+          ~s(      {:mailglass_admin, path: "#{mg}/mailglass_admin"},\n) <>
+          ~s(      {:mailglass_inbound, path: "#{mg}/mailglass_inbound"},\n)
+
+      "hex" ->
+        v = System.get_env("VERSION") || raise "hex mode requires VERSION"
+        vi = System.get_env("VERSION_INBOUND") || ""
+
+        inbound =
+          if System.get_env("INCLUDE_INBOUND") == "true" and vi != "" do
+            ~s(      {:mailglass_inbound, "== #{vi}"},\n)
+          else
+            ""
+          end
+
+        ~s(      {:mailglass, "== #{v}"},\n) <> ~s(      {:mailglass_admin, "== #{v}"},\n) <> inbound
+
+      other ->
+        raise "unknown DEP_MODE: #{inspect(other)}"
+    end
+
+  content = File.read!("mix.exs")
+  updated = String.replace(content, ~r/(defp deps do\n\s*\[\n)/, "\\1" <> entries, global: false)
+  File.write!("mix.exs", updated)
+'
+grep -F "mailglass" mix.exs
+
+mix deps.get
+
+# --- install -------------------------------------------------------------------
+mix mailglass.install
+
+# --- OPS-01 guard: a fresh --no-mailer install must stay HTTP-client-agnostic --
+if ! grep -F "config :swoosh, :api_client, false" config/runtime.exs; then
+  echo "OPS-01 failed: generated runtime.exs is missing config :swoosh, :api_client, false."
+  exit 1
+fi
+if grep -Eq '^[[:space:]]*config :swoosh, :api_client, Swoosh\.ApiClient\.Finch([[:space:]]|$)' config/runtime.exs; then
+  echo "OPS-01 failed: generated runtime.exs contains an uncommented Swoosh.ApiClient.Finch line."
+  exit 1
+fi
+if grep -Eq '"(hackney|finch)":' mix.lock; then
+  echo "OPS-01 failed: fresh --no-mailer install resolved hackney or finch in mix.lock."
+  exit 1
+fi
+echo "OPS-01 guard passed."
+
+# --- compile (warnings are errors) ---------------------------------------------
+mix compile --warnings-as-errors 2>&1 | tee compile.log
+if grep -F "UndefinedFunctionError" compile.log; then
+  echo "Smoke failed: UndefinedFunctionError detected in compile output."
+  exit 1
+fi
+
+# --- boot endpoint and curl /dev/mail/ -----------------------------------------
+MIX_ENV=dev mix phx.server &
+SERVER_PID=$!
+# shellcheck disable=SC2064
+trap "kill ${SERVER_PID} 2>/dev/null || true" EXIT
+
+DEADLINE=$(( SECONDS + 30 ))
+until curl -fsI http://localhost:4000/dev/mail/ >/dev/null 2>&1; do
+  if [ "${SECONDS}" -ge "${DEADLINE}" ]; then
+    echo "Smoke failed: endpoint did not respond on /dev/mail/ within 30s."
+    exit 1
+  fi
+  sleep 2
+done
+
+STATUS=$(curl -fs -o /dev/null -w "%{http_code}" http://localhost:4000/dev/mail/)
+echo "GET /dev/mail/ -> HTTP ${STATUS}"
+if [ "${STATUS}" != "200" ]; then
+  echo "Smoke failed: /dev/mail/ returned ${STATUS}, expected 200."
+  exit 1
+fi
+echo "Endpoint smoke passed."

--- a/test/mailglass/install/install_compile_test.exs
+++ b/test/mailglass/install/install_compile_test.exs
@@ -1,0 +1,27 @@
+defmodule Mailglass.Install.CompileTest do
+  # async: false — run_install!/2 uses File.cd!/2 (process-global cwd), matching
+  # the other installer tests.
+  use ExUnit.Case, async: false
+
+  import Mailglass.Test.InstallerFixtureHelpers
+
+  @moduletag timeout: 120_000
+
+  # The sibling installer tests assert that snippets are inserted and that a
+  # golden hash matches, but never compile the generated output — which is how
+  # the endpoint anchor-split and the escaped `<%%=` HEEx layout both shipped.
+  # These tests parse every generated `.ex`/`.exs` and compile every `.heex` so
+  # any codegen that produces uncompilable Elixir/HEEx fails before merge.
+
+  test "every generated/edited artifact from a default install parses/compiles" do
+    fixture_root = new_fixture_root!("compile-default")
+    run_install!(fixture_root, [])
+    assert_generated_artifacts_compile!(fixture_root)
+  end
+
+  test "every generated/edited artifact from a --no-admin install parses/compiles" do
+    fixture_root = new_fixture_root!("compile-no-admin")
+    run_install!(fixture_root, ["--no-admin"])
+    assert_generated_artifacts_compile!(fixture_root)
+  end
+end

--- a/test/mailglass/install/install_first_preview_smoke_test.exs
+++ b/test/mailglass/install/install_first_preview_smoke_test.exs
@@ -22,20 +22,27 @@ defmodule Mailglass.Install.FirstPreviewSmokeTest do
     router_path = Path.join(fixture_root, "lib/example_web/router.ex")
     layout_path = Path.join(fixture_root, "lib/example_web/components/layouts/mailglass.html.heex")
     workflow_path = Path.expand("../../../.github/workflows/post-publish-smoke.yml", __DIR__)
+    script_path = Path.expand("../../../scripts/consumer_install_smoke.sh", __DIR__)
 
     assert File.read!(router_path) =~ ~s(mailglass_admin_routes "/mail")
     assert File.exists?(layout_path)
     assert File.exists?(mailable_path)
 
-    workflow = File.read!(workflow_path)
+    # The release-window gate flow (phx.new -> install -> compile -> boot ->
+    # GET /dev/mail/) lives in the shared script; the post-publish workflow and
+    # the PR-time ci.yml `Installer Host Smoke` job both call it.
+    script = File.read!(script_path)
 
-    assert workflow =~
+    assert script =~
              "mix phx.new sandbox --module Sandbox --app sandbox --no-ecto --no-mailer --install"
 
-    assert workflow =~ "Run mix mailglass.install"
-    assert workflow =~ "Compile, fail on warnings"
-    assert workflow =~ "Boot endpoint and curl /dev/mail/"
-    assert workflow =~ "GET /dev/mail/ → HTTP ${STATUS}"
+    assert script =~ "mix mailglass.install"
+    assert script =~ "mix compile --warnings-as-errors"
+    assert script =~ "OPS-01 guard passed."
+    assert script =~ "GET /dev/mail/ -> HTTP ${STATUS}"
+
+    workflow = File.read!(workflow_path)
+    assert workflow =~ "bash scripts/consumer_install_smoke.sh"
     assert workflow =~ "canonical release-window gate"
 
     elapsed_ms = System.monotonic_time(:millisecond) - started_ms

--- a/test/support/installer_fixture_helpers.ex
+++ b/test/support/installer_fixture_helpers.ex
@@ -46,6 +46,77 @@ defmodule Mailglass.Test.InstallerFixtureHelpers do
     :ok
   end
 
+  @doc """
+  Compile-validates every generated/edited artifact in an installed fixture.
+
+  The other installer tests only assert that snippets were inserted or that a
+  golden hash matches — they never compile the output, which is how a corrupted
+  `endpoint.ex` (anchor split mid-`use Phoenix.Endpoint, otp_app:`) and an
+  escaped `<%%=` HEEx layout both shipped undetected. This walks the installed
+  tree and fails loudly, naming the offending file:
+
+    * `.ex` / `.exs` → parsed with `Code.string_to_quoted!/2` (syntax only;
+      NOT full compile — host files expand `use Phoenix.Endpoint`/router macros
+      that need the whole app, which is the PR-time host smoke's job).
+    * `.heex` → run through the Phoenix HEEx tag engine so template-syntax
+      errors raise.
+  """
+  def assert_generated_artifacts_compile!(fixture_root) when is_binary(fixture_root) do
+    fixture_root
+    |> Path.join("**/*")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.filter(&File.regular?/1)
+    |> Enum.each(&assert_artifact_compiles!(&1, fixture_root))
+
+    :ok
+  end
+
+  defp assert_artifact_compiles!(path, fixture_root) do
+    case Path.extname(path) do
+      ext when ext in [".ex", ".exs"] -> assert_elixir_parses!(path, fixture_root)
+      ".heex" -> assert_heex_compiles!(path, fixture_root)
+      _ -> :ok
+    end
+  end
+
+  defp assert_elixir_parses!(path, fixture_root) do
+    Code.string_to_quoted!(File.read!(path), file: path)
+    :ok
+  rescue
+    error in [SyntaxError, TokenMissingError, MismatchedDelimiterError] ->
+      reraise(
+        """
+        Generated Elixir artifact does not parse: #{Path.relative_to(path, fixture_root)}
+        #{Exception.message(error)}
+        """,
+        __STACKTRACE__
+      )
+  end
+
+  defp assert_heex_compiles!(path, fixture_root) do
+    source = File.read!(path)
+
+    EEx.compile_string(source,
+      engine: Phoenix.LiveView.TagEngine,
+      tag_handler: Phoenix.LiveView.HTMLEngine,
+      file: path,
+      line: 1,
+      caller: __ENV__,
+      source: source
+    )
+
+    :ok
+  rescue
+    error ->
+      reraise(
+        """
+        Generated HEEx artifact does not compile: #{Path.relative_to(path, fixture_root)}
+        #{Exception.message(error)}
+        """,
+        __STACKTRACE__
+      )
+  end
+
   def snapshot_tree!(fixture_root) when is_binary(fixture_root) do
     files =
       fixture_root


### PR DESCRIPTION
## Why

The installer test suite asserted that snippets were inserted / a golden hash matched, but **never compiled the generated host**. That's how the 1.4.3–1.4.5 install bug stack shipped undetected — a corrupted `endpoint.ex` (anchor split mid-`use Phoenix.Endpoint, otp_app:`) and an escaped `<%%=` HEEx layout both passed every existing test. The only thing that compiled+booted a real install was the post-publish smoke, which runs `release: published` only (never on a PR).

This closes the gap with two complementary layers.

## Layer 1 — fast in-process artifact validation (every PR, zero network)

`Mailglass.Test.InstallerFixtureHelpers.assert_generated_artifacts_compile!/1` walks the installed temp fixture and:
- parses every generated `.ex`/`.exs` with `Code.string_to_quoted!/2`
- compiles every `.heex` via the Phoenix HEEx tag engine (`Phoenix.LiveView.TagEngine`/`HTMLEngine`)

New `test/mailglass/install/install_compile_test.exs` (default + `--no-admin`) runs in the existing `verify.installer` → **Installer Golden Gate** lane.

**Proof it works:** temporarily reintroducing each original bug makes the new test red with the exact smoke errors:
- endpoint → `...endpoint.ex:11:1: error: syntax error before: ','`
- HEEx → `...mailglass.html.heex:4:9: expected attribute name`

(Parse-only for `.ex` — host files expand `use Phoenix.Endpoint`/router macros that need the whole app; that's Layer 2's job.)

## Layer 2 — shift-left the consumer-install smoke (advisory)

Extracted the post-publish "Consumer install" steps into `scripts/consumer_install_smoke.sh`, parameterized by `DEP_MODE`:
- `hex` → published versions (post-publish-smoke.yml now calls this — **behavior unchanged**)
- `path` → **working tree** local path deps

New advisory `ci.yml` job **Installer Host Smoke** runs the script with `DEP_MODE=path` on PRs: `phx.new → install → OPS-01 guard → compile --warnings-as-errors → boot → GET /dev/mail/ == 200`. Catches the macro / runtime (`:inets`) / OPS-01 / boot classes Layer 1 can't. `continue-on-error: true` for now (phx.new + deps.get + boot are network-dependent); promotion-to-required notes are in the job comment.

`install_first_preview_smoke_test.exs` repointed to assert the flow against the shared script (the literals moved out of the workflow YAML).

## Verification

- `mix test test/mailglass/install/` → 11 tests, 0 failures
- `DEP_MODE=path MAILGLASS_PATH=$PWD bash scripts/consumer_install_smoke.sh` → `GET /dev/mail/ -> 200` locally
- `mix format --check-formatted` + `mix credo --strict` clean
- Test/CI-only — **no library release needed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)