### PR TITLE
ci: promote Installer Host Smoke to required + unify upload-artifact pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: mix compile --no-optional-deps --warnings-as-errors
 
   installer_host_smoke:
-    name: Installer Host Smoke (Advisory)
+    name: Installer Host Smoke
     runs-on: ubuntu-latest
     # Shift-left of the post-publish consumer-install smoke: runs the SAME
     # scripts/consumer_install_smoke.sh against the WORKING TREE (local path
@@ -119,11 +119,11 @@ jobs:
     # the 1.4.3-1.4.5 install bug stack ship). The fast in-process counterpart is
     # test/mailglass/install/install_compile_test.exs.
     #
-    # Advisory for now: phx.new + the sandbox's own deps.get + server boot are
-    # network-dependent and slower than the required lanes. Promote to a required
-    # context (drop continue-on-error; add to scripts/setup_branch_protection.sh)
-    # once it has proven stable.
-    continue-on-error: true
+    # Required (promoted from advisory once proven stable): this is a
+    # branch-protection context in scripts/setup_branch_protection.sh. It is
+    # network-dependent (phx.new + the sandbox's own deps.get + server boot)
+    # and slower than the other required lanes, but guards the install path
+    # that the 1.4.3-1.4.5 bug stack shipped through.
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -55,7 +55,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload hygiene artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: repo-hygiene
           path: repo-hygiene.json

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -155,6 +155,7 @@ The exact required contexts are:
 - `Support Contract Admin (Elixir 1.18 / OTP 27)`
 - `Compile No Optional Deps (Elixir 1.18 / OTP 27)`
 - `Trust Lane Repo Head (Elixir 1.18 / OTP 27)`
+- `Installer Host Smoke` (shift-left consumer-install smoke; promoted from advisory)
 
 Release trust claims also require green trust evidence beyond the required
 branch-protection contexts: the clean-baseline and published-version trust
@@ -275,6 +276,7 @@ usage, Hex/HexDocs checks, branch-protection result, and 60-minute outcome.
    - `Support Contract Admin (Elixir 1.18 / OTP 27)`
    - `Compile No Optional Deps (Elixir 1.18 / OTP 27)`
    - `Trust Lane Repo Head (Elixir 1.18 / OTP 27)`
+   - `Installer Host Smoke` (shift-left consumer-install smoke; promoted from advisory)
    - Phase 38 prepublish proof/export bundle (`38-01-PREPUBLISH-PROOF.md`)
    - Phase 38 install/upgrade rehearsal artifact (`38-02-REHEARSAL-EVIDENCE.md`)
    - Trust-runner checkpoint artifacts:

--- a/scripts/setup_branch_protection.sh
+++ b/scripts/setup_branch_protection.sh
@@ -19,6 +19,7 @@ REQUIRED_CHECKS=(
   "Support Contract Admin (Elixir 1.18 / OTP 27)"
   "Compile No Optional Deps (Elixir 1.18 / OTP 27)"
   "Trust Lane Repo Head (Elixir 1.18 / OTP 27)"
+  "Installer Host Smoke"
 )
 
 print_expected_text() {
@@ -28,6 +29,7 @@ Expected required status checks:
   - Support Contract Admin (Elixir 1.18 / OTP 27)
   - Compile No Optional Deps (Elixir 1.18 / OTP 27)
   - Trust Lane Repo Head (Elixir 1.18 / OTP 27)
+  - Installer Host Smoke
 
 Expected non-context branch protection fields:
   - required_status_checks.strict: true


### PR DESCRIPTION
## What

Quiet-maintenance hygiene, part B.

1. **Promote `Installer Host Smoke` to a required branch-protection check.** The advisory consumer-install smoke has proven stable (~1m34s). Drops `continue-on-error`, renames the job to `Installer Host Smoke` (clean required-context name), and registers it in `scripts/setup_branch_protection.sh` + `MAINTAINING.md`. Locks in the shift-left guard that catches installer/compile/boot regressions on the PR rather than after publishing (the gap the 1.4.3–1.4.5 install-bug stack shipped through).
2. **Unify the `actions/upload-artifact` pin.** Dependabot #45 moved 5 of 6 occurrences to v7.0.1 but left `repo-hygiene.yml` on v4.6.2; this aligns it so all occurrences share one major.

## Post-merge action
Run `GH_TOKEN=<admin-pat> ./scripts/setup_branch_protection.sh main` to apply the new required context (the workflow rename means the old `Installer Host Smoke (Advisory)` context is retired).

## Verification
- `mix test test/scripts/required_checks_test.exs` (REQUIRED_CHECKS ↔ print_expected_text sync) → green. ✅
- This PR's own `Installer Host Smoke` run exercises the promoted (now-blocking) job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)