### PR TITLE
docs: refresh CLAUDE.md provenance footer to current 1.4.5 line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,4 +127,4 @@ Encoded for GSD in `~/.claude/get-shit-done/USER-PROFILE.md` (advisor mode, `ven
 MIT across all sibling packages. Forever. (See PROJECT.md D-02.)
 
 ---
-*Generated: 2026-04-21 from `.planning/` artifacts. "What This Is" + "Where to Look" refreshed 2026-05-22 (v0.1→v1.1 shipped, v1.2 in flight; added `guides/jobs.md` + `.planning/research/JTBD-COVERAGE.md`).*
+*Generated: 2026-04-21 from `.planning/` artifacts. "What This Is" + "Where to Look" refreshed 2026-05-22; current-state reconciled 2026-06-03 to live `mailglass` 1.4.5 / `mailglass_admin` 1.4.5 / `mailglass_inbound` 1.1.5 (v1.6 shipped, quiet-maintenance posture).*


### PR DESCRIPTION
Final hygiene straggler: the CLAUDE.md provenance footer still read `v1.2 in flight` (dated 2026-05-22). Refreshed to record the 2026-06-03 reconciliation to live `mailglass` 1.4.5 / `mailglass_admin` 1.4.5 / `mailglass_inbound` 1.1.5, quiet-maintenance posture. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)