### PR TITLE
fix(admin-test): run inbound migrations in the browser-server DB bootstrap

### DIFF
--- a/mailglass_admin/test/support/admin_bootstrap.ex
+++ b/mailglass_admin/test/support/admin_bootstrap.ex
@@ -60,8 +60,18 @@ defmodule MailglassAdmin.TestSupport.AdminBootstrap do
   end
 
   def ensure_repo_started!(opts \\ []) do
-    migrations_path =
+    core_migrations_path =
       :code.priv_dir(:mailglass)
+      |> Path.join("repo/migrations")
+
+    # Inbound migrations land in the SAME admin test DB so the operator/preview
+    # browser surface can query inbound rows (InboundRecord/ExecutionRun/replay)
+    # against MailglassAdmin.TestRepo — config :mailglass_inbound, :repo,
+    # MailglassAdmin.TestRepo (config/test.exs). Mirrors test/test_helper.exs;
+    # without it the OperatorBrowserServer crashes on the first inbound query
+    # (relation "mailglass_inbound_replay_runs" does not exist).
+    inbound_migrations_path =
+      :code.priv_dir(:mailglass_inbound)
       |> Path.join("repo/migrations")
 
     test_repo_config = Application.get_env(:mailglass, MailglassAdmin.TestRepo)
@@ -81,7 +91,8 @@ defmodule MailglassAdmin.TestSupport.AdminBootstrap do
 
     {:ok, _, _} =
       Ecto.Migrator.with_repo(MailglassAdmin.TestRepo, fn repo ->
-        Ecto.Migrator.run(repo, migrations_path, :up, all: true, log: false)
+        Ecto.Migrator.run(repo, core_migrations_path, :up, all: true, log: false)
+        Ecto.Migrator.run(repo, inbound_migrations_path, :up, all: true, log: false)
       end)
 
     Application.put_env(:mailglass, MailglassAdmin.TestRepo, test_repo_config)


### PR DESCRIPTION
## Why
The `Preview Capture Advisory` CI lane (and `Operator Browser Gate`, same code path) fails deterministically:

```
** (Postgrex.Error) ERROR 42P01 (undefined_table) relation "mailglass_inbound_replay_runs" does not exist
[operator-browser-server] sandbox owner started …
```

These lanes boot `OperatorBrowserServer`, whose DB bootstrap (`AdminBootstrap.ensure_repo_started!/1`) applied **only core mailglass migrations** — but the operator/preview inbound surface queries `mailglass_inbound_*` tables. The admin ExUnit suite avoids this because `test/test_helper.exs` already migrates **both** paths into `MailglassAdmin.TestRepo`; only the standalone browser-server bootstrap was missing the inbound run.

## Change
One file — mirror the proven `test_helper.exs` pattern in `ensure_repo_started!/1`: compute the inbound migrations path and run it after core, inside the existing `Ecto.Migrator.with_repo` block. (Earlier #70 made the publish gate *tolerate* this red lane; this fixes the root cause so it's actually green.)

## Verification
- `mix compile --warnings-as-errors` clean (test env).
- Reproduced locally: a clean test DB + `ensure_repo_started!` now creates `mailglass_inbound_replay_runs` / `_records` / `_evidence` (`to_regclass` non-null) — previously absent.
- `cd mailglass_admin && mix test` → 191 tests, 0 failures (no regression).
- This PR's `Preview Capture Advisory` lane should now go **green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)