### PR TITLE
fix(inbound): release the mailglass == 1.9.0 pin to restore resolution

### DIFF
--- a/mailglass_inbound/mix.exs
+++ b/mailglass_inbound/mix.exs
@@ -122,6 +122,11 @@ defmodule MailglassInbound.MixProject do
   # cutting an inbound release — the published inbound then still carries the
   # previous pin and blocks dependency resolution beside the new core. A
   # `fix(inbound):` release is required either way to ship the new pin to Hex.
+  #
+  # 2026-06-26: re-pin 1.8.0 -> 1.9.0 for the v1.13 (mailglass 1.9.0) release.
+  # The chore release commit (#90) pre-synced the pin; this fix(inbound) cuts the
+  # paired inbound release that ships == 1.9.0 and unblocks the mailglass_admin
+  # 1.9.0 publish (whose deps.get resolves inbound beside the new core).
   defp mailglass_dep do
     if System.get_env("MIX_PUBLISH") == "true" do
       {:mailglass, "== 1.9.0"}


### PR DESCRIPTION
## Why

mailglass 1.9.0 published as part of the v1.13 linked release, but **mailglass_admin 1.9.0 failed to publish** with a Hex resolution conflict: `mailglass_admin` depends on `mailglass_inbound ~> 1.1`, and the latest published inbound (1.5.0) pins `mailglass == 1.8.0` — unsolvable beside `mailglass 1.9.0`.

The release commit (#90) already synced inbound's source pin to `== 1.9.0`, but a `chore` commit doesn't trigger a Release Please inbound bump, so the *published* inbound still carries the old pin. This `fix(inbound)` cuts the paired inbound release (1.5.0 → 1.6.0) that ships the `== 1.9.0` pin to Hex.

## After this merges
1. Release Please opens an inbound release PR (mailglass_inbound 1.6.0).
2. Merging it publishes inbound 1.6.0 (pins `mailglass == 1.9.0`).
3. Re-run the failed `publish-admin` job → mailglass_admin 1.9.0 resolves and publishes.

Completes the v1.13 linked release (core ✓ / admin pending / inbound pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)